### PR TITLE
feat: Allow skipping STORAGE_ACCESS_KEY_ID, STORAGE_SECRET_ACCESS_KEY…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "crikket",
@@ -99,7 +98,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@base-ui/react": "catalog:",
         "@crikket-io/capture": "workspace:*",
@@ -339,7 +338,7 @@
     },
     "sdks/capture": {
       "name": "@crikket-io/capture",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@crikket/capture-core": "workspace:*",
         "@crikket/shared": "workspace:*",

--- a/packages/bug-reports/src/lib/storage.ts
+++ b/packages/bug-reports/src/lib/storage.ts
@@ -36,8 +36,8 @@ interface S3StorageOptions {
   region: string
   endpoint?: string
   addressingStyle?: S3AddressingStyle
-  accessKeyId: string
-  secretAccessKey: string
+  accessKeyId?: string
+  secretAccessKey?: string
   publicUrl?: string
 }
 
@@ -62,10 +62,16 @@ export function createS3StorageProvider(
     }),
     requestChecksumCalculation: "WHEN_REQUIRED",
     responseChecksumValidation: "WHEN_REQUIRED",
-    credentials: {
-      accessKeyId: options.accessKeyId,
-      secretAccessKey: options.secretAccessKey,
-    },
+    // Omit credentials when keys are absent — the SDK credential chain
+    // (IRSA, instance profile, ECS task role, etc.) will be used instead.
+    ...(options.accessKeyId && options.secretAccessKey
+      ? {
+          credentials: {
+            accessKeyId: options.accessKeyId,
+            secretAccessKey: options.secretAccessKey,
+          },
+        }
+      : {}),
   })
 
   const getUrl = (filename: string): Promise<string> => {
@@ -370,25 +376,11 @@ function serializeCleanupError(error: unknown): string {
 }
 
 function getCloudStorageConfig(): S3StorageOptions {
-  const requiredKeys = [
-    ["STORAGE_BUCKET", env.STORAGE_BUCKET],
-    ["STORAGE_ACCESS_KEY_ID", env.STORAGE_ACCESS_KEY_ID],
-    ["STORAGE_SECRET_ACCESS_KEY", env.STORAGE_SECRET_ACCESS_KEY],
-  ] as const
-
-  const missingKeys = requiredKeys
-    .filter(([, value]) => !value)
-    .map(([name]) => name)
-
-  if (missingKeys.length > 0) {
+  if (!env.STORAGE_BUCKET) {
     throw new Error(
-      `Missing required cloud storage env vars: ${missingKeys.join(", ")}. Local storage support has been removed.`
+      "Missing required cloud storage env var: STORAGE_BUCKET. Local storage support has been removed."
     )
   }
-
-  const bucket = env.STORAGE_BUCKET!
-  const accessKeyId = env.STORAGE_ACCESS_KEY_ID!
-  const secretAccessKey = env.STORAGE_SECRET_ACCESS_KEY!
 
   const region = env.STORAGE_REGION ?? (env.STORAGE_ENDPOINT ? "auto" : null)
   if (!region) {
@@ -398,12 +390,12 @@ function getCloudStorageConfig(): S3StorageOptions {
   }
 
   return {
-    bucket,
+    bucket: env.STORAGE_BUCKET,
     region,
     endpoint: env.STORAGE_ENDPOINT,
     addressingStyle: env.STORAGE_ADDRESSING_STYLE,
-    accessKeyId,
-    secretAccessKey,
+    accessKeyId: env.STORAGE_ACCESS_KEY_ID,
+    secretAccessKey: env.STORAGE_SECRET_ACCESS_KEY,
     publicUrl: env.STORAGE_PUBLIC_URL,
   }
 }


### PR DESCRIPTION
When running within EKS or EC2 instances it's helpful to be able to run the app without setting these keys.

This allows the use of EC2/EKS role and instance profiles.