### PR TITLE
feat(github): self-service GitHub issue forwarding for bug reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Every report is designed to reduce the usual debugging back-and-forth.
 | Technical context | Console logs and network requests attached to the report |
 | Sharing | Public or private share links per report |
 | Collaboration | Team workspaces, invites, and report management |
+| Integrations | Forward reports to GitHub as issues with attachments |
 | Deployment | Quick and easy self-hosting |
 
 ## Quick Start

--- a/apps/docs/content/docs/self-hosting/github-issues.mdx
+++ b/apps/docs/content/docs/self-hosting/github-issues.mdx
@@ -1,0 +1,147 @@
+---
+title: GitHub Issue Forwarding
+description: Forward Crikket bug reports to a GitHub repo as issues, with capture and debugger artifacts attached.
+---
+
+Crikket can automatically forward every submitted bug report to a GitHub
+repository as an issue. The issue body includes the report's description,
+context table, reproduction steps, console logs, and network requests.
+Capture (screenshot or recording) and debugger payload artifacts are
+committed to a dedicated `crikket-attachments` branch on the target repo
+and linked from the issue.
+
+The integration is configured **per organization** from the web app.
+There is no server-wide env-var setup — each organization owner points
+at their own repo and token.
+
+## Prerequisites
+
+- A GitHub repository you control (public or private; private is fine).
+- A GitHub token with access to that repo.
+
+### Token scopes
+
+A fine-grained personal access token scoped to the target repo is
+recommended. Grant these repository permissions:
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Contents | Read and write | Create the `crikket-attachments` branch and commit artifacts |
+| Issues | Read and write | Create issues |
+| Metadata | Read-only | Required by GitHub for any fine-grained token |
+
+A classic token with the `repo` scope also works (or `public_repo` if the
+target repo is public). Avoid tokens with broader scopes than necessary.
+
+## Configure
+
+1. Sign in as an organization admin.
+2. Open **Settings → Integrations → GitHub**.
+3. Enter the target repo in `owner/repo` form (e.g. `my-team/app`).
+4. Paste the GitHub token.
+5. Save.
+
+The token is encrypted at rest with AES-256-GCM using a key derived from
+`BETTER_AUTH_SECRET`; the plaintext is never stored or re-surfaced in the
+UI. To rotate the token, enter a new one and save again. To keep the
+existing token while changing the repo, leave the token field blank.
+
+## What Happens When a Report Is Forwarded
+
+When a bug report is submitted, Crikket:
+
+1. Looks up the submitter's organization integration config. If no config
+   is present, the forward is skipped.
+2. Ensures the `crikket-attachments` branch exists on the target repo
+   (created from the default branch's HEAD if missing).
+3. Uploads the capture (screenshot `.png` or recording `.webm`) and the
+   debugger payload (`.debugger.json`) to
+   `crikket-attachments:/<report-id>/...` via the Contents API.
+4. Creates a new issue on the target repo titled
+   `[crikket] <report title>` with labels `crikket` and
+   `priority:<level>` (when priority is set).
+5. Renders the issue body with:
+   - **Description** — the submitter's description text.
+   - **Context** table — URL, browser, OS, viewport, priority, tags,
+     duration, SDK version.
+   - **Artifacts** — links to the uploaded capture and debugger payload.
+   - **Reproduction steps** — action events from the session.
+   - **Console logs** — up to 50 most recent entries.
+   - **Network requests** — up to 50 requests in a collapsed table.
+
+The upload and issue creation happen asynchronously after the report is
+persisted. A failure in forwarding never fails the report submission
+itself; failures are logged as non-fatal errors.
+
+## Attachment Links and Private Repos
+
+Attachment URLs use the form `https://github.com/<owner>/<repo>/blob/crikket-attachments/<report-id>/<filename>`.
+
+For **private repos**, a viewer must be signed in to GitHub with access
+to the repo — the link will then resolve through GitHub's authenticated
+viewer. The issue body does **not** embed inline image previews for
+captures: GitHub's image proxy (Camo) cannot fetch private-repo content,
+so an embed would always render as a broken icon. The filename link is
+clickable instead, and opens in GitHub's blob viewer where PNGs and JSON
+render natively.
+
+For **public repos**, the same links work for anyone without
+authentication.
+
+## Attachment Size Limit
+
+Individual artifacts are capped at **40 MB**. GitHub's Contents API
+hard-caps at 100 MB per file, and the 40 MB cap leaves headroom for
+base64 overhead in the request body and keeps issue load times sane.
+
+Oversize artifacts are not uploaded. Instead, the issue body shows a
+"not uploaded — retrieve from crikket: report id `<id>`" notice for that
+artifact. The report itself is still persisted in Crikket, so the
+artifact is retrievable from the Crikket dashboard.
+
+## Removing the Integration
+
+Return to **Settings → Integrations → GitHub** and click **Remove**.
+The stored config (repo + encrypted token) is deleted immediately.
+
+The `crikket-attachments` branch on the target repo is **not**
+auto-cleaned. To remove previously uploaded artifacts, delete the branch
+manually (or the individual files) from GitHub. Note that deleting the
+branch will break the artifact links in already-forwarded issues.
+
+## Scope
+
+- One config per organization. Members of the organization share a
+  single target repo.
+- Only organization admins can view, modify, or remove the config.
+- Reports submitted by organizations **without** a configured
+  integration are persisted in Crikket as usual; no forward attempt is
+  made.
+
+## Troubleshooting
+
+**Issue was never created.** Check the server logs for
+`[github-integration]` entries. Common causes:
+
+- Token lacks `issues:write` or `contents:write`. Re-check the token's
+  repository permissions.
+- Repo not found or not accessible by the token. Verify `owner/repo`
+  spelling and that the token can see the repo.
+- Branch creation failed (the attachments branch couldn't be created
+  from the default branch). Confirm the repo has at least one commit on
+  its default branch and the token has `contents:write`.
+
+**Artifact link returns 404 in the browser.** The link uses the
+`github.com/<repo>/blob/...` form and requires the viewer to be signed
+in to GitHub with repo access. The old `raw.githubusercontent.com` form
+does not work for private repos without a bearer token.
+
+**Inline screenshot shows as a broken image.** Expected for private
+repos — see
+[Attachment Links and Private Repos](#attachment-links-and-private-repos).
+The filename link above the (missing) preview opens the image in
+GitHub's blob viewer.
+
+**Token rotated and old reports' forwards stopped working.** Enter the
+new token in the settings form. Historical issues and attachments are
+unaffected; only future forwards need the new credentials.

--- a/apps/docs/content/docs/self-hosting/index.mdx
+++ b/apps/docs/content/docs/self-hosting/index.mdx
@@ -11,6 +11,7 @@ This section covers how to deploy and operate Crikket in your own infrastructure
 - [Production Setup](/docs/self-hosting/production)
 - [Storage Setup](/docs/self-hosting/storage)
 - [Operations](/docs/self-hosting/operations)
+- [GitHub Issue Forwarding](/docs/self-hosting/github-issues)
 - [Troubleshooting](/docs/self-hosting/troubleshooting)
 
 ## Architecture

--- a/apps/docs/content/docs/self-hosting/meta.json
+++ b/apps/docs/content/docs/self-hosting/meta.json
@@ -7,6 +7,7 @@
     "production",
     "storage",
     "operations",
+    "github-issues",
     "troubleshooting"
   ]
 }

--- a/apps/server/src/capture/finalize-route.ts
+++ b/apps/server/src/capture/finalize-route.ts
@@ -86,6 +86,7 @@ export async function handleCaptureFinalize(input: {
         reportId: result.id,
         shareUrl: new URL(result.shareUrl, input.shareOrigin).toString(),
         warnings: result.warnings,
+        githubIssueUrl: result.githubIssueUrl,
       },
       {
         headers: authorization.rateLimitHeaders,

--- a/apps/web/src/app/(protected)/(dashboard)/settings/_components/github-integration-form.tsx
+++ b/apps/web/src/app/(protected)/(dashboard)/settings/_components/github-integration-form.tsx
@@ -47,8 +47,7 @@ export function GithubIntegrationForm({
       try {
         const result = await client.githubIntegration.upsert({
           repo: value.repo.trim(),
-          token:
-            value.token.trim().length > 0 ? value.token.trim() : undefined,
+          token: value.token.trim().length > 0 ? value.token.trim() : undefined,
         })
         setConfigured(result.configured)
         toast.success("GitHub integration saved")
@@ -63,11 +62,11 @@ export function GithubIntegrationForm({
   })
 
   async function handleRemove() {
-    if (
-      !window.confirm(
-        "Remove the GitHub integration? New bug reports will stop forwarding to the repo."
-      )
-    ) {
+    // biome-ignore lint/suspicious/noAlert: browser confirm is adequate for this destructive admin action; a styled AlertDialog is a follow-up.
+    const ok = window.confirm(
+      "Remove the GitHub integration? New bug reports will stop forwarding to the repo."
+    )
+    if (!ok) {
       return
     }
     setIsRemoving(true)
@@ -112,8 +111,7 @@ export function GithubIntegrationForm({
                 value={field.state.value}
               />
               <FieldDescription>
-                Must be in <code>owner/repo</code> format (e.g.
-                {" "}
+                Must be in <code>owner/repo</code> format (e.g.{" "}
                 <code>acme/webapp</code>).
               </FieldDescription>
               {isInvalid ? (

--- a/apps/web/src/app/(protected)/(dashboard)/settings/_components/github-integration-form.tsx
+++ b/apps/web/src/app/(protected)/(dashboard)/settings/_components/github-integration-form.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { Button } from "@crikket/ui/components/ui/button"
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from "@crikket/ui/components/ui/field"
+import { Input } from "@crikket/ui/components/ui/input"
+import { useForm } from "@tanstack/react-form"
+import { useRouter } from "nextjs-toploader/app"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { githubIntegrationFormSchema } from "@/lib/schema/settings"
+import { client } from "@/utils/orpc"
+
+import { getRequestErrorMessage } from "../_lib/get-request-error-message"
+
+interface GithubIntegrationFormProps {
+  initialConfigured: boolean
+  initialRepo: string | null
+}
+
+export function GithubIntegrationForm({
+  initialConfigured,
+  initialRepo,
+}: GithubIntegrationFormProps) {
+  const router = useRouter()
+  const [configured, setConfigured] = useState(initialConfigured)
+  const [isRemoving, setIsRemoving] = useState(false)
+
+  const form = useForm({
+    defaultValues: {
+      repo: initialRepo ?? "",
+      token: "",
+    },
+    validators: {
+      onChange: githubIntegrationFormSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (!configured && value.token.trim().length === 0) {
+        toast.error("A GitHub token is required the first time.")
+        return
+      }
+      try {
+        const result = await client.githubIntegration.upsert({
+          repo: value.repo.trim(),
+          token:
+            value.token.trim().length > 0 ? value.token.trim() : undefined,
+        })
+        setConfigured(result.configured)
+        toast.success("GitHub integration saved")
+        // Clear the token field after a successful save so the user can re-enter
+        // a different token later without triggering "empty = keep existing" confusion.
+        form.setFieldValue("token", "")
+        router.refresh()
+      } catch (error) {
+        toast.error(getRequestErrorMessage(error))
+      }
+    },
+  })
+
+  async function handleRemove() {
+    if (
+      !window.confirm(
+        "Remove the GitHub integration? New bug reports will stop forwarding to the repo."
+      )
+    ) {
+      return
+    }
+    setIsRemoving(true)
+    try {
+      await client.githubIntegration.remove()
+      setConfigured(false)
+      form.reset({ repo: "", token: "" })
+      toast.success("GitHub integration removed")
+      router.refresh()
+    } catch (error) {
+      toast.error(getRequestErrorMessage(error))
+    } finally {
+      setIsRemoving(false)
+    }
+  }
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        form.handleSubmit()
+      }}
+    >
+      <form.Field name="repo">
+        {(field) => {
+          const isInvalid =
+            field.state.meta.isTouched && field.state.meta.errors.length > 0
+
+          return (
+            <Field data-invalid={isInvalid}>
+              <FieldLabel htmlFor={field.name}>Repository</FieldLabel>
+              <Input
+                aria-invalid={isInvalid}
+                autoComplete="off"
+                id={field.name}
+                name={field.name}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+                placeholder="owner/repo"
+                value={field.state.value}
+              />
+              <FieldDescription>
+                Must be in <code>owner/repo</code> format (e.g.
+                {" "}
+                <code>acme/webapp</code>).
+              </FieldDescription>
+              {isInvalid ? (
+                <FieldError errors={field.state.meta.errors} />
+              ) : null}
+            </Field>
+          )
+        }}
+      </form.Field>
+
+      <form.Field name="token">
+        {(field) => {
+          const isInvalid =
+            field.state.meta.isTouched && field.state.meta.errors.length > 0
+
+          return (
+            <Field data-invalid={isInvalid}>
+              <FieldLabel htmlFor={field.name}>GitHub token</FieldLabel>
+              <Input
+                aria-invalid={isInvalid}
+                autoComplete="off"
+                id={field.name}
+                name={field.name}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+                placeholder={
+                  configured
+                    ? "•••••••• — leave empty to keep the stored token"
+                    : "github_pat_..."
+                }
+                type="password"
+                value={field.state.value}
+              />
+              <FieldDescription>
+                Fine-grained PAT with <strong>Issues: Read and write</strong>{" "}
+                and <strong>Contents: Read and write</strong> on the target
+                repository. Tokens are encrypted at rest.
+              </FieldDescription>
+              {isInvalid ? (
+                <FieldError errors={field.state.meta.errors} />
+              ) : null}
+            </Field>
+          )
+        }}
+      </form.Field>
+
+      <div className="flex items-center gap-3">
+        <Button disabled={form.state.isSubmitting} type="submit">
+          {form.state.isSubmitting
+            ? "Saving..."
+            : configured
+              ? "Update integration"
+              : "Save integration"}
+        </Button>
+        {configured ? (
+          <Button
+            disabled={isRemoving || form.state.isSubmitting}
+            onClick={handleRemove}
+            type="button"
+            variant="ghost"
+          >
+            {isRemoving ? "Removing..." : "Remove integration"}
+          </Button>
+        ) : null}
+      </div>
+    </form>
+  )
+}

--- a/apps/web/src/app/(protected)/(dashboard)/settings/_components/settings-navigation.tsx
+++ b/apps/web/src/app/(protected)/(dashboard)/settings/_components/settings-navigation.tsx
@@ -1,7 +1,13 @@
 "use client"
 
 import { cn } from "@crikket/ui/lib/utils"
-import { Building2, CreditCard, KeyRound, UserRound } from "lucide-react"
+import {
+  Building2,
+  CreditCard,
+  Github,
+  KeyRound,
+  UserRound,
+} from "lucide-react"
 import type { Route } from "next"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -24,6 +30,12 @@ const SETTINGS_ITEMS = [
     title: "Public Keys",
     description: "Widget keys, origins, embeds",
     icon: KeyRound,
+  },
+  {
+    href: "/settings/integrations",
+    title: "Integrations",
+    description: "Forward reports to external tools",
+    icon: Github,
   },
   {
     href: "/settings/billing",

--- a/apps/web/src/app/(protected)/(dashboard)/settings/integrations/page.tsx
+++ b/apps/web/src/app/(protected)/(dashboard)/settings/integrations/page.tsx
@@ -1,0 +1,121 @@
+import { authClient } from "@crikket/auth/client"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@crikket/ui/components/ui/card"
+import type { Metadata } from "next"
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { getProtectedAuthData } from "@/app/(protected)/_lib/get-protected-auth-data"
+import { client } from "@/utils/orpc"
+
+import { GithubIntegrationForm } from "../_components/github-integration-form"
+import { getRequestErrorMessage } from "../_lib/get-request-error-message"
+
+export const metadata: Metadata = {
+  title: "Integrations",
+  description: "Forward Crikket bug reports to external tools.",
+}
+
+export default async function IntegrationsSettingsPage() {
+  const { organizations, session } = await getProtectedAuthData()
+
+  if (!session) {
+    redirect("/login")
+  }
+
+  if (organizations.length === 0) {
+    redirect("/onboarding")
+  }
+
+  const activeOrganization =
+    organizations.find(
+      (organization) => organization.id === session.session.activeOrganizationId
+    ) ?? organizations[0]
+
+  const requestHeaders = await headers()
+  const authFetchOptions = {
+    fetchOptions: {
+      headers: requestHeaders,
+    },
+  }
+
+  const { data: memberRoleData } =
+    await authClient.organization.getActiveMemberRole({
+      query: {
+        organizationId: activeOrganization.id,
+      },
+      ...authFetchOptions,
+    })
+
+  const canManage =
+    memberRoleData?.role === "owner" || memberRoleData?.role === "admin"
+
+  const githubIntegrationState = canManage
+    ? await client.githubIntegration
+        .get()
+        .then((data) => ({ data, error: null as unknown }))
+        .catch((error: unknown) => ({
+          data: { configured: false as const, repo: null as string | null },
+          error,
+        }))
+    : {
+        data: { configured: false as const, repo: null as string | null },
+        error: null as unknown,
+      }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-semibold text-xl tracking-tight">Integrations</h2>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Forward new bug reports to external tools for {activeOrganization.name}.
+        </p>
+      </div>
+
+      {canManage ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>GitHub Issues</CardTitle>
+            <CardDescription>
+              Create an issue in your repo whenever a bug report is submitted.
+              Screenshots, recordings, and debugger payloads are committed to a
+              dedicated <code>crikket-attachments</code> branch and linked from
+              the issue.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <GithubIntegrationForm
+              initialConfigured={githubIntegrationState.data.configured}
+              initialRepo={githubIntegrationState.data.repo}
+            />
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Admin access required</CardTitle>
+            <CardDescription>
+              Only organization admins and owners can manage integrations.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-muted-foreground text-sm">
+            Ask an organization admin to configure the GitHub integration for
+            this workspace.
+          </CardContent>
+        </Card>
+      )}
+
+      {githubIntegrationState.error ? (
+        <p className="text-destructive text-sm">
+          Failed to load integration:{" "}
+          {getRequestErrorMessage(githubIntegrationState.error)}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/app/(protected)/(dashboard)/settings/integrations/page.tsx
+++ b/apps/web/src/app/(protected)/(dashboard)/settings/integrations/page.tsx
@@ -73,7 +73,8 @@ export default async function IntegrationsSettingsPage() {
       <div>
         <h2 className="font-semibold text-xl tracking-tight">Integrations</h2>
         <p className="mt-1 text-muted-foreground text-sm">
-          Forward new bug reports to external tools for {activeOrganization.name}.
+          Forward new bug reports to external tools for{" "}
+          {activeOrganization.name}.
         </p>
       </div>
 

--- a/apps/web/src/app/s/[id]/_components/bug-report-sidebar.tsx
+++ b/apps/web/src/app/s/[id]/_components/bug-report-sidebar.tsx
@@ -105,6 +105,21 @@ export function BugReportSidebar({
                 <DetailRow label="Browser" value={deviceInfo?.browser} />
                 <DetailRow label="OS" value={deviceInfo?.os} />
                 <DetailRow label="Viewport" value={deviceInfo?.viewport} />
+                {data.githubIssueUrl ? (
+                  <div className="grid gap-1">
+                    <span className="font-medium text-muted-foreground text-xs">
+                      GitHub Issue
+                    </span>
+                    <a
+                      className="break-all text-sm underline underline-offset-2 hover:no-underline"
+                      href={data.githubIssueUrl}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      {data.githubIssueUrl}
+                    </a>
+                  </div>
+                ) : null}
               </div>
             </div>
             <Separator />

--- a/apps/web/src/lib/schema/settings.ts
+++ b/apps/web/src/lib/schema/settings.ts
@@ -76,6 +76,6 @@ export const githubIntegrationFormSchema = z.object({
     .regex(/^[^/\s]+\/[^/\s]+$/, {
       message: "Use the format owner/repo",
     }),
-  // Token is only required the first time; on updates an empty value means "keep existing".
-  token: z.string().optional(),
+  // Token is only required the first time; on updates an empty string means "keep existing".
+  token: z.string(),
 })

--- a/apps/web/src/lib/schema/settings.ts
+++ b/apps/web/src/lib/schema/settings.ts
@@ -68,3 +68,14 @@ export const inviteMemberFormSchema = z.object({
   email: z.email("Enter a valid email address"),
   role: z.enum(["admin", "member"]),
 })
+
+export const githubIntegrationFormSchema = z.object({
+  repo: z
+    .string()
+    .trim()
+    .regex(/^[^/\s]+\/[^/\s]+$/, {
+      message: "Use the format owner/repo",
+    }),
+  // Token is only required the first time; on updates an empty value means "keep existing".
+  token: z.string().optional(),
+})

--- a/packages/api/src/routers/github-integration.ts
+++ b/packages/api/src/routers/github-integration.ts
@@ -1,0 +1,15 @@
+import {
+  getIntegration,
+  removeIntegration,
+  upsertIntegration,
+} from "@crikket/bug-reports/procedures/github-integration"
+
+/**
+ * GitHub Integration Router
+ * Per-organization config for forwarding bug reports to a GitHub repo.
+ */
+export const githubIntegrationRouter = {
+  get: getIntegration,
+  upsert: upsertIntegration,
+  remove: removeIntegration,
+}

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6,6 +6,7 @@ import { authRouter } from "./auth"
 import { billingRouter } from "./billing"
 import { bugReportRouter } from "./bug-report"
 import { captureKeyRouter } from "./capture-key"
+import { githubIntegrationRouter } from "./github-integration"
 
 export const appRouter = {
   healthCheck: publicProcedure.handler(() => {
@@ -15,6 +16,7 @@ export const appRouter = {
   billing: billingRouter,
   bugReport: bugReportRouter,
   captureKey: captureKeyRouter,
+  githubIntegration: githubIntegrationRouter,
 }
 export type AppRouter = typeof appRouter
 export type AppRouterClient = RouterClient<typeof appRouter>

--- a/packages/bug-reports/src/lib/github-integration-config.ts
+++ b/packages/bug-reports/src/lib/github-integration-config.ts
@@ -1,0 +1,93 @@
+import { db } from "@crikket/db"
+import { organizationGithubIntegration } from "@crikket/db/schema/github-integration"
+import { env } from "@crikket/env/server"
+import {
+  decryptSecret,
+  encryptSecret,
+} from "@crikket/shared/lib/server/crypto"
+import { eq } from "drizzle-orm"
+import { nanoid } from "nanoid"
+
+export interface GithubIntegrationSummary {
+  configured: boolean
+  repo: string | null
+}
+
+export interface GithubIntegrationCredentials {
+  repo: string
+  token: string
+}
+
+export async function getGithubIntegrationSummary(
+  organizationId: string
+): Promise<GithubIntegrationSummary> {
+  const row = await db.query.organizationGithubIntegration.findFirst({
+    where: eq(organizationGithubIntegration.organizationId, organizationId),
+    columns: { repo: true },
+  })
+  if (!row) return { configured: false, repo: null }
+  return { configured: true, repo: row.repo }
+}
+
+export async function getGithubIntegrationCredentials(
+  organizationId: string
+): Promise<GithubIntegrationCredentials | null> {
+  const row = await db.query.organizationGithubIntegration.findFirst({
+    where: eq(organizationGithubIntegration.organizationId, organizationId),
+    columns: { repo: true, tokenEncrypted: true },
+  })
+  if (!row) return null
+  try {
+    const token = decryptSecret(row.tokenEncrypted, env.BETTER_AUTH_SECRET)
+    return { repo: row.repo, token }
+  } catch {
+    // Encrypted blob unreadable (corrupted row or key rotated). Treat as unconfigured.
+    return null
+  }
+}
+
+export async function upsertGithubIntegration(input: {
+  organizationId: string
+  repo: string
+  /** If undefined, preserves the existing token. Required when no row exists yet. */
+  token?: string
+}): Promise<void> {
+  const existing = await db.query.organizationGithubIntegration.findFirst({
+    where: eq(organizationGithubIntegration.organizationId, input.organizationId),
+    columns: { id: true, tokenEncrypted: true },
+  })
+
+  if (!existing) {
+    if (!input.token) {
+      throw new Error("Token is required to create a GitHub integration.")
+    }
+    await db.insert(organizationGithubIntegration).values({
+      id: nanoid(16),
+      organizationId: input.organizationId,
+      repo: input.repo,
+      tokenEncrypted: encryptSecret(input.token, env.BETTER_AUTH_SECRET),
+    })
+    return
+  }
+
+  const nextTokenEncrypted = input.token
+    ? encryptSecret(input.token, env.BETTER_AUTH_SECRET)
+    : existing.tokenEncrypted
+
+  await db
+    .update(organizationGithubIntegration)
+    .set({
+      repo: input.repo,
+      tokenEncrypted: nextTokenEncrypted,
+      updatedAt: new Date(),
+    })
+    .where(eq(organizationGithubIntegration.id, existing.id))
+}
+
+export async function deleteGithubIntegration(
+  organizationId: string
+): Promise<void> {
+  await db
+    .delete(organizationGithubIntegration)
+    .where(eq(organizationGithubIntegration.organizationId, organizationId))
+}

--- a/packages/bug-reports/src/lib/github-integration-config.ts
+++ b/packages/bug-reports/src/lib/github-integration-config.ts
@@ -1,10 +1,7 @@
 import { db } from "@crikket/db"
 import { organizationGithubIntegration } from "@crikket/db/schema/github-integration"
 import { env } from "@crikket/env/server"
-import {
-  decryptSecret,
-  encryptSecret,
-} from "@crikket/shared/lib/server/crypto"
+import { decryptSecret, encryptSecret } from "@crikket/shared/lib/server/crypto"
 import { eq } from "drizzle-orm"
 import { nanoid } from "nanoid"
 
@@ -53,7 +50,10 @@ export async function upsertGithubIntegration(input: {
   token?: string
 }): Promise<void> {
   const existing = await db.query.organizationGithubIntegration.findFirst({
-    where: eq(organizationGithubIntegration.organizationId, input.organizationId),
+    where: eq(
+      organizationGithubIntegration.organizationId,
+      input.organizationId
+    ),
     columns: { id: true, tokenEncrypted: true },
   })
 

--- a/packages/bug-reports/src/lib/integrations.ts
+++ b/packages/bug-reports/src/lib/integrations.ts
@@ -1,6 +1,5 @@
 import { db } from "@crikket/db"
 import { bugReport } from "@crikket/db/schema/bug-report"
-import { env } from "@crikket/env/server"
 import { reportNonFatalError } from "@crikket/shared/lib/errors"
 import { eq } from "drizzle-orm"
 import { gunzipSync } from "node:zlib"
@@ -76,7 +75,15 @@ export async function forwardBugReportToGitHub(
       return
     }
 
-    const credentials = await resolveCredentials(report.organizationId)
+    const credentials = await getGithubIntegrationCredentials(
+      report.organizationId
+    ).catch((error) => {
+      reportNonFatalError(
+        `[github-integration] Failed to load credentials for org ${report.organizationId}`,
+        error
+      )
+      return null
+    })
     if (!credentials) {
       return
     }
@@ -125,29 +132,6 @@ export async function forwardBugReportToGitHub(
       error
     )
   }
-}
-
-async function resolveCredentials(
-  organizationId: string
-): Promise<{ repo: string; token: string } | null> {
-  // Per-org DB config takes precedence; env vars are a dev/bootstrap fallback.
-  const fromDb = await getGithubIntegrationCredentials(organizationId).catch(
-    (error) => {
-      reportNonFatalError(
-        `[github-integration] Failed to load DB credentials for org ${organizationId}`,
-        error
-      )
-      return null
-    }
-  )
-  if (fromDb) return fromDb
-
-  const envRepo = env.GITHUB_ISSUES_REPO
-  const envToken = env.GITHUB_ISSUES_TOKEN
-  if (envRepo && envToken) {
-    return { repo: envRepo, token: envToken }
-  }
-  return null
 }
 
 async function uploadAttachments(input: {

--- a/packages/bug-reports/src/lib/integrations.ts
+++ b/packages/bug-reports/src/lib/integrations.ts
@@ -1,0 +1,585 @@
+import { db } from "@crikket/db"
+import { bugReport } from "@crikket/db/schema/bug-report"
+import { env } from "@crikket/env/server"
+import { reportNonFatalError } from "@crikket/shared/lib/errors"
+import { eq } from "drizzle-orm"
+import { gunzipSync } from "node:zlib"
+import { getGithubIntegrationCredentials } from "./github-integration-config"
+import { getStorageProvider } from "./storage"
+
+const MAX_LOG_LINES = 50
+const MAX_NETWORK_ROWS = 50
+const MAX_ACTION_ROWS = 50
+const MAX_MESSAGE_LEN = 400
+const GITHUB_API_VERSION = "2022-11-28"
+const REPO_PATTERN = /^[^/\s]+\/[^/\s]+$/
+const ATTACHMENTS_BRANCH = "crikket-attachments"
+// GitHub's Contents API hard-caps at 100MB per file; 40MB leaves headroom for
+// base64 overhead in the JSON request body and keeps issue load times sane.
+const MAX_ATTACHMENT_BYTES = 40 * 1024 * 1024
+
+interface DeviceInfo {
+  browser?: string
+  os?: string
+  viewport?: string
+}
+
+interface ReportMetadata {
+  duration?: string
+  durationMs?: number
+  pageTitle?: string
+  sdkVersion?: string
+  submittedVia?: string
+}
+
+type AttachmentKind = "capture" | "debugger"
+
+interface AttachmentResult {
+  kind: AttachmentKind
+  label: string
+  filename: string
+  /** Set when the artifact was uploaded successfully. */
+  url?: string
+  /** Set when upload was skipped because of size. */
+  tooLargeBytes?: number
+  /** Set when upload failed for any other reason. */
+  error?: string
+}
+
+export async function forwardBugReportToGitHub(
+  bugReportId: string
+): Promise<void> {
+  try {
+    const report = await db.query.bugReport.findFirst({
+      where: eq(bugReport.id, bugReportId),
+      with: {
+        logs: {
+          orderBy: (t, { asc: a }) => [a(t.timestamp)],
+          limit: MAX_LOG_LINES,
+        },
+        networkRequests: {
+          orderBy: (t, { asc: a }) => [a(t.timestamp)],
+          limit: MAX_NETWORK_ROWS,
+        },
+        actions: {
+          orderBy: (t, { asc: a }) => [a(t.timestamp)],
+          limit: MAX_ACTION_ROWS,
+        },
+      },
+    })
+
+    if (!report) {
+      reportNonFatalError(
+        `[github-integration] Bug report ${bugReportId} not found for forwarding`,
+        new Error("not_found")
+      )
+      return
+    }
+
+    const credentials = await resolveCredentials(report.organizationId)
+    if (!credentials) {
+      return
+    }
+    const { repo, token } = credentials
+    if (!REPO_PATTERN.test(repo)) {
+      reportNonFatalError(
+        `[github-integration] GitHub repo must be "owner/repo"; got "${repo}"`,
+        new Error("invalid_repo"),
+        { once: true }
+      )
+      return
+    }
+
+    const attachments = await uploadAttachments({ report, repo, token })
+
+    const body = renderIssueBody({ report, attachments })
+    const title = renderIssueTitle(report)
+    const labels = buildLabels(report.priority)
+
+    const response = await ghFetch(
+      `https://api.github.com/repos/${repo}/issues`,
+      {
+        token,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, body, labels }),
+      }
+    )
+
+    if (!response.ok) {
+      const text = await safeReadText(response)
+      reportNonFatalError(
+        `[github-integration] Failed to create GitHub issue for ${bugReportId} (status ${response.status})`,
+        new Error(text || response.statusText)
+      )
+      return
+    }
+
+    const issue = (await response.json()) as { html_url?: string; number?: number }
+    console.info(
+      `[github-integration] Created GitHub issue #${issue.number ?? "?"} for bug report ${bugReportId}: ${issue.html_url ?? "(no url)"}`
+    )
+  } catch (error) {
+    reportNonFatalError(
+      `[github-integration] Unexpected failure forwarding bug report ${bugReportId}`,
+      error
+    )
+  }
+}
+
+async function resolveCredentials(
+  organizationId: string
+): Promise<{ repo: string; token: string } | null> {
+  // Per-org DB config takes precedence; env vars are a dev/bootstrap fallback.
+  const fromDb = await getGithubIntegrationCredentials(organizationId).catch(
+    (error) => {
+      reportNonFatalError(
+        `[github-integration] Failed to load DB credentials for org ${organizationId}`,
+        error
+      )
+      return null
+    }
+  )
+  if (fromDb) return fromDb
+
+  const envRepo = env.GITHUB_ISSUES_REPO
+  const envToken = env.GITHUB_ISSUES_TOKEN
+  if (envRepo && envToken) {
+    return { repo: envRepo, token: envToken }
+  }
+  return null
+}
+
+async function uploadAttachments(input: {
+  report: ReportWithRelations
+  repo: string
+  token: string
+}): Promise<AttachmentResult[]> {
+  const { report, repo, token } = input
+  const storage = getStorageProvider()
+  const results: AttachmentResult[] = []
+  let branchEnsured = false
+
+  const ensureBranch = async (): Promise<boolean> => {
+    if (branchEnsured) return true
+    try {
+      await ensureAttachmentsBranch({ repo, token, branch: ATTACHMENTS_BRANCH })
+      branchEnsured = true
+      return true
+    } catch (error) {
+      reportNonFatalError(
+        `[github-integration] Could not ensure ${ATTACHMENTS_BRANCH} branch on ${repo}`,
+        error
+      )
+      return false
+    }
+  }
+
+  if (report.captureKey) {
+    const captureLabel =
+      report.attachmentType === "video" ? "Recording" : "Screenshot"
+    const captureFilename = filenameForCapture(report)
+    const result: AttachmentResult = {
+      kind: "capture",
+      label: captureLabel,
+      filename: captureFilename,
+    }
+    try {
+      const bytes = await storage.read(report.captureKey)
+      if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+        result.tooLargeBytes = bytes.byteLength
+      } else if (await ensureBranch()) {
+        result.url = await uploadArtifact({
+          repo,
+          token,
+          branch: ATTACHMENTS_BRANCH,
+          path: `${report.id}/${captureFilename}`,
+          content: bytes,
+          message: `crikket: capture for bug report ${report.id}`,
+        })
+      } else {
+        result.error = "branch setup failed"
+      }
+    } catch (error) {
+      result.error = error instanceof Error ? error.message : String(error)
+    }
+    results.push(result)
+  }
+
+  if (report.debuggerKey) {
+    const debuggerFilename = `${report.id}.debugger.json`
+    const result: AttachmentResult = {
+      kind: "debugger",
+      label: "Debugger payload",
+      filename: debuggerFilename,
+    }
+    try {
+      const raw = await storage.read(report.debuggerKey)
+      const bytes =
+        report.debuggerContentEncoding === "gzip"
+          ? Buffer.from(gunzipSync(raw))
+          : raw
+      if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+        result.tooLargeBytes = bytes.byteLength
+      } else if (await ensureBranch()) {
+        result.url = await uploadArtifact({
+          repo,
+          token,
+          branch: ATTACHMENTS_BRANCH,
+          path: `${report.id}/${debuggerFilename}`,
+          content: bytes,
+          message: `crikket: debugger payload for bug report ${report.id}`,
+        })
+      } else {
+        result.error = "branch setup failed"
+      }
+    } catch (error) {
+      result.error = error instanceof Error ? error.message : String(error)
+    }
+    results.push(result)
+  }
+
+  return results
+}
+
+async function ensureAttachmentsBranch(input: {
+  repo: string
+  token: string
+  branch: string
+}): Promise<void> {
+  const check = await ghFetch(
+    `https://api.github.com/repos/${input.repo}/branches/${encodeURIComponent(input.branch)}`,
+    { token: input.token }
+  )
+  if (check.ok) return
+  if (check.status !== 404) {
+    throw new Error(
+      `check ${input.branch}: ${check.status} ${await safeReadText(check)}`
+    )
+  }
+
+  const repoInfoResp = await ghFetch(
+    `https://api.github.com/repos/${input.repo}`,
+    { token: input.token }
+  )
+  if (!repoInfoResp.ok) {
+    throw new Error(
+      `fetch repo: ${repoInfoResp.status} ${await safeReadText(repoInfoResp)}`
+    )
+  }
+  const repoInfo = (await repoInfoResp.json()) as { default_branch: string }
+
+  const refResp = await ghFetch(
+    `https://api.github.com/repos/${input.repo}/git/ref/heads/${encodeURIComponent(repoInfo.default_branch)}`,
+    { token: input.token }
+  )
+  if (!refResp.ok) {
+    throw new Error(
+      `fetch default ref: ${refResp.status} ${await safeReadText(refResp)}`
+    )
+  }
+  const refData = (await refResp.json()) as { object: { sha: string } }
+
+  const createResp = await ghFetch(
+    `https://api.github.com/repos/${input.repo}/git/refs`,
+    {
+      token: input.token,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ref: `refs/heads/${input.branch}`,
+        sha: refData.object.sha,
+      }),
+    }
+  )
+  // 422 = already exists (race condition between check and create)
+  if (!createResp.ok && createResp.status !== 422) {
+    throw new Error(
+      `create ref: ${createResp.status} ${await safeReadText(createResp)}`
+    )
+  }
+}
+
+async function uploadArtifact(input: {
+  repo: string
+  token: string
+  branch: string
+  path: string
+  content: Buffer
+  message: string
+}): Promise<string> {
+  const contentsUrl = `https://api.github.com/repos/${input.repo}/contents/${encodePath(input.path)}`
+
+  // If the file already exists on the branch we need its sha for an overwrite.
+  const existing = await ghFetch(
+    `${contentsUrl}?ref=${encodeURIComponent(input.branch)}`,
+    { token: input.token }
+  )
+  const existingSha = existing.ok
+    ? ((await existing.json()) as { sha?: string }).sha
+    : undefined
+
+  const put = await ghFetch(contentsUrl, {
+    token: input.token,
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      message: input.message,
+      content: input.content.toString("base64"),
+      branch: input.branch,
+      sha: existingSha,
+    }),
+  })
+  if (!put.ok) {
+    throw new Error(
+      `upload ${input.path}: ${put.status} ${await safeReadText(put)}`
+    )
+  }
+
+  // Use the github.com/<repo>/blob URL rather than raw.githubusercontent.com.
+  // raw.githubusercontent.com 404s for private repos without a bearer token,
+  // so a plain browser click on a raw URL fails even for authorized viewers.
+  // The /blob URL goes through GitHub's auth flow and works for any repo member.
+  return `https://github.com/${input.repo}/blob/${encodeURIComponent(input.branch)}/${encodePath(input.path)}`
+}
+
+async function ghFetch(
+  url: string,
+  init: RequestInit & { token: string }
+): Promise<Response> {
+  const { token, headers, ...rest } = init
+  return fetch(url, {
+    ...rest,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": GITHUB_API_VERSION,
+      "User-Agent": "crikket-self-hosted",
+      ...(headers ?? {}),
+    },
+  })
+}
+
+function encodePath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/")
+}
+
+function filenameForCapture(report: ReportWithRelations): string {
+  if (report.attachmentType === "video") {
+    return `${report.id}.webm`
+  }
+  // Default to png for screenshots (matches crikket SDK default content type).
+  return `${report.id}.png`
+}
+
+interface ReportWithRelations {
+  id: string
+  organizationId: string
+  title: string | null
+  description: string | null
+  priority: string
+  url: string | null
+  status: string
+  tags: string[] | null
+  attachmentType: string | null
+  deviceInfo: unknown
+  metadata: unknown
+  createdAt: Date
+  captureKey: string | null
+  debuggerKey: string | null
+  debuggerContentEncoding: string | null
+  logs: Array<{
+    level: string
+    message: string
+    timestamp: Date
+  }>
+  networkRequests: Array<{
+    method: string
+    url: string
+    status: number | null
+    duration: number | null
+    timestamp: Date
+  }>
+  actions: Array<{
+    type: string
+    target: string | null
+    timestamp: Date
+  }>
+}
+
+function renderIssueTitle(report: ReportWithRelations): string {
+  const trimmed = report.title?.trim()
+  if (trimmed) {
+    return `[crikket] ${trimmed}`
+  }
+  if (report.url) {
+    return `[crikket] Bug report from ${report.url}`
+  }
+  return `[crikket] Bug report ${report.id}`
+}
+
+function renderIssueBody(input: {
+  report: ReportWithRelations
+  attachments: AttachmentResult[]
+}): string {
+  const { report, attachments } = input
+  const device = (report.deviceInfo ?? {}) as DeviceInfo
+  const metadata = (report.metadata ?? {}) as ReportMetadata
+  const sections: string[] = []
+
+  sections.push(
+    `> Forwarded from Crikket bug report \`${report.id}\` on ${report.createdAt.toISOString()}`
+  )
+
+  if (report.description?.trim()) {
+    sections.push("## Description", report.description.trim())
+  }
+
+  sections.push(
+    "## Context",
+    renderContextTable({
+      URL: report.url ?? "—",
+      Browser: device.browser ?? "—",
+      OS: device.os ?? "—",
+      Viewport: device.viewport ?? "—",
+      Priority: report.priority,
+      Tags: report.tags?.length ? report.tags.join(", ") : "—",
+      Attachment: report.attachmentType ?? "—",
+      Duration: metadata.duration ?? "—",
+      "SDK version": metadata.sdkVersion ?? "—",
+      "Submitted via": metadata.submittedVia ?? "—",
+    })
+  )
+
+  const attachmentSection = renderAttachmentsSection(report, attachments)
+  if (attachmentSection) {
+    sections.push(attachmentSection)
+  }
+
+  if (report.actions.length > 0) {
+    sections.push(
+      "## Reproduction steps",
+      renderActionList(report.actions)
+    )
+  }
+
+  if (report.logs.length > 0) {
+    sections.push(
+      "## Console logs",
+      "```",
+      report.logs
+        .map(
+          (log) =>
+            `[${log.timestamp.toISOString()}] ${log.level.toUpperCase()}: ${truncate(log.message)}`
+        )
+        .join("\n"),
+      "```"
+    )
+  }
+
+  if (report.networkRequests.length > 0) {
+    sections.push(
+      "<details><summary>Network requests</summary>",
+      "",
+      renderNetworkTable(report.networkRequests),
+      "",
+      "</details>"
+    )
+  }
+
+  return sections.join("\n\n")
+}
+
+function renderAttachmentsSection(
+  report: ReportWithRelations,
+  attachments: AttachmentResult[]
+): string | null {
+  if (attachments.length === 0) return null
+
+  const lines: string[] = ["## Artifacts"]
+  for (const attachment of attachments) {
+    if (attachment.url) {
+      // No inline ![](...) embed: GitHub's Camo image proxy refuses to fetch
+      // private-repo content, so an embed would render as a broken image icon.
+      // The link below opens the file via GitHub's authed blob viewer.
+      lines.push(
+        `- **${attachment.label}** — [${attachment.filename}](${attachment.url})`
+      )
+    } else if (attachment.tooLargeBytes != null) {
+      const mb = (attachment.tooLargeBytes / (1024 * 1024)).toFixed(1)
+      lines.push(
+        `- **${attachment.label}** — not uploaded (${mb} MB exceeds the ${
+          MAX_ATTACHMENT_BYTES / (1024 * 1024)
+        } MB per-file limit). Retrieve from crikket: report id \`${report.id}\``
+      )
+    } else {
+      lines.push(
+        `- **${attachment.label}** — upload failed (${attachment.error ?? "unknown error"}). Retrieve from crikket: report id \`${report.id}\``
+      )
+    }
+  }
+  return lines.join("\n")
+}
+
+function renderContextTable(rows: Record<string, string>): string {
+  const lines = ["| Field | Value |", "| --- | --- |"]
+  for (const [key, value] of Object.entries(rows)) {
+    lines.push(`| ${key} | ${escapeCell(value)} |`)
+  }
+  return lines.join("\n")
+}
+
+function renderNetworkTable(
+  rows: Array<{
+    method: string
+    url: string
+    status: number | null
+    duration: number | null
+  }>
+): string {
+  const lines = ["| Method | Status | Duration | URL |", "| --- | --- | --- | --- |"]
+  for (const row of rows) {
+    lines.push(
+      `| ${row.method} | ${row.status ?? "—"} | ${
+        row.duration != null ? `${row.duration}ms` : "—"
+      } | ${escapeCell(truncate(row.url))} |`
+    )
+  }
+  return lines.join("\n")
+}
+
+function renderActionList(
+  actions: Array<{ type: string; target: string | null }>
+): string {
+  return actions
+    .map((action, idx) => {
+      const target = action.target ? ` — \`${truncate(action.target, 120)}\`` : ""
+      return `${idx + 1}. **${action.type}**${target}`
+    })
+    .join("\n")
+}
+
+function buildLabels(priority: string): string[] {
+  const labels = ["crikket"]
+  if (priority && priority !== "none") {
+    labels.push(`priority:${priority}`)
+  }
+  return labels
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ")
+}
+
+function truncate(value: string, max = MAX_MESSAGE_LEN): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}…`
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500)
+  } catch {
+    return ""
+  }
+}

--- a/packages/bug-reports/src/lib/integrations.ts
+++ b/packages/bug-reports/src/lib/integrations.ts
@@ -45,61 +45,49 @@ interface AttachmentResult {
   error?: string
 }
 
-export async function forwardBugReportToGitHub(
-  bugReportId: string
-): Promise<void> {
-  try {
-    const report = await db.query.bugReport.findFirst({
-      where: eq(bugReport.id, bugReportId),
-      with: {
-        logs: {
-          orderBy: (t, { asc: a }) => [a(t.timestamp)],
-          limit: MAX_LOG_LINES,
-        },
-        networkRequests: {
-          orderBy: (t, { asc: a }) => [a(t.timestamp)],
-          limit: MAX_NETWORK_ROWS,
-        },
-        actions: {
-          orderBy: (t, { asc: a }) => [a(t.timestamp)],
-          limit: MAX_ACTION_ROWS,
-        },
-      },
-    })
+export interface CreatedGitHubIssue {
+  htmlUrl: string
+  number: number
+  /** Repo + token captured for the follow-up attachment phase. */
+  repo: string
+  token: string
+}
 
+/**
+ * Create a GitHub issue for the bug report (synchronous, fast).
+ *
+ * Posts a single Issues API call without attachments — attachment uploads
+ * touch GitHub's Contents API per file and run sequentially, which can take
+ * seconds and would block the capture-submit response. The caller awaits this
+ * to surface the issue URL in the success modal, then fires
+ * attachAndUpdateGitHubIssue in the background to upload artifacts and PATCH
+ * the issue body to embed the links.
+ *
+ * Returns null when:
+ *   - the bug report is missing,
+ *   - the org has no GitHub integration configured,
+ *   - the integration is misconfigured (bad repo format), or
+ *   - the GitHub API call itself failed.
+ * All of these are treated as non-fatal — capture submission still succeeds.
+ */
+export async function createGitHubIssue(
+  bugReportId: string
+): Promise<CreatedGitHubIssue | null> {
+  try {
+    const report = await loadReport(bugReportId)
     if (!report) {
       reportNonFatalError(
         `[github-integration] Bug report ${bugReportId} not found for forwarding`,
         new Error("not_found")
       )
-      return
-    }
-
-    const credentials = await getGithubIntegrationCredentials(
-      report.organizationId
-    ).catch((error) => {
-      reportNonFatalError(
-        `[github-integration] Failed to load credentials for org ${report.organizationId}`,
-        error
-      )
       return null
-    })
-    if (!credentials) {
-      return
     }
+
+    const credentials = await loadCredentials(report.organizationId)
+    if (!credentials) return null
     const { repo, token } = credentials
-    if (!REPO_PATTERN.test(repo)) {
-      reportNonFatalError(
-        `[github-integration] GitHub repo must be "owner/repo"; got "${repo}"`,
-        new Error("invalid_repo"),
-        { once: true }
-      )
-      return
-    }
 
-    const attachments = await uploadAttachments({ report, repo, token })
-
-    const body = renderIssueBody({ report, attachments })
+    const body = renderIssueBody({ report, attachments: [] })
     const title = renderIssueTitle(report)
     const labels = buildLabels(report.priority)
 
@@ -119,22 +107,146 @@ export async function forwardBugReportToGitHub(
         `[github-integration] Failed to create GitHub issue for ${bugReportId} (status ${response.status})`,
         new Error(text || response.statusText)
       )
-      return
+      return null
     }
 
     const issue = (await response.json()) as {
       html_url?: string
       number?: number
     }
+    if (!issue.html_url || typeof issue.number !== "number") {
+      reportNonFatalError(
+        `[github-integration] GitHub issue response for ${bugReportId} missing html_url/number`,
+        new Error("malformed_response")
+      )
+      return null
+    }
     console.info(
-      `[github-integration] Created GitHub issue #${issue.number ?? "?"} for bug report ${bugReportId}: ${issue.html_url ?? "(no url)"}`
+      `[github-integration] Created GitHub issue #${issue.number} for bug report ${bugReportId}: ${issue.html_url}`
     )
+    return { htmlUrl: issue.html_url, number: issue.number, repo, token }
   } catch (error) {
     reportNonFatalError(
-      `[github-integration] Unexpected failure forwarding bug report ${bugReportId}`,
+      `[github-integration] Unexpected failure creating GitHub issue for ${bugReportId}`,
+      error
+    )
+    return null
+  }
+}
+
+/**
+ * Upload bug-report attachments to the configured repo and PATCH the issue
+ * body to embed the resulting links. Designed to run fire-and-forget after
+ * createGitHubIssue — failures are logged and never propagated.
+ *
+ * The repo + token are passed in (rather than re-loaded) so the credentials
+ * fetched during issue creation are reused, avoiding a second decrypt round-
+ * trip and a race where the integration is rotated mid-flow.
+ */
+export async function attachAndUpdateGitHubIssue(input: {
+  bugReportId: string
+  issueNumber: number
+  repo: string
+  token: string
+}): Promise<void> {
+  const { bugReportId, issueNumber, repo, token } = input
+  try {
+    const report = await loadReport(bugReportId)
+    if (!report) return
+
+    const attachments = await uploadAttachments({ report, repo, token })
+    if (attachments.length === 0) return
+
+    const body = renderIssueBody({ report, attachments })
+
+    const response = await ghFetch(
+      `https://api.github.com/repos/${repo}/issues/${issueNumber}`,
+      {
+        token,
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body }),
+      }
+    )
+
+    if (!response.ok) {
+      const text = await safeReadText(response)
+      reportNonFatalError(
+        `[github-integration] Failed to PATCH issue #${issueNumber} with attachments (status ${response.status})`,
+        new Error(text || response.statusText)
+      )
+    }
+  } catch (error) {
+    reportNonFatalError(
+      `[github-integration] Unexpected failure attaching artifacts for ${bugReportId}`,
       error
     )
   }
+}
+
+/**
+ * Back-compat orchestrator: create + attach in one call. Existing callers
+ * (and the original test suite) keep working; new callers (upload-session)
+ * use createGitHubIssue + attachAndUpdateGitHubIssue separately so the
+ * issue URL is available synchronously.
+ */
+export async function forwardBugReportToGitHub(
+  bugReportId: string
+): Promise<void> {
+  const created = await createGitHubIssue(bugReportId)
+  if (!created) return
+  await attachAndUpdateGitHubIssue({
+    bugReportId,
+    issueNumber: created.number,
+    repo: created.repo,
+    token: created.token,
+  })
+}
+
+function loadReport(
+  bugReportId: string
+): Promise<ReportWithRelations | undefined> {
+  return db.query.bugReport.findFirst({
+    where: eq(bugReport.id, bugReportId),
+    with: {
+      logs: {
+        orderBy: (t, { asc: a }) => [a(t.timestamp)],
+        limit: MAX_LOG_LINES,
+      },
+      networkRequests: {
+        orderBy: (t, { asc: a }) => [a(t.timestamp)],
+        limit: MAX_NETWORK_ROWS,
+      },
+      actions: {
+        orderBy: (t, { asc: a }) => [a(t.timestamp)],
+        limit: MAX_ACTION_ROWS,
+      },
+    },
+  }) as Promise<ReportWithRelations | undefined>
+}
+
+async function loadCredentials(
+  organizationId: string
+): Promise<{ repo: string; token: string } | null> {
+  const credentials = await getGithubIntegrationCredentials(
+    organizationId
+  ).catch((error) => {
+    reportNonFatalError(
+      `[github-integration] Failed to load credentials for org ${organizationId}`,
+      error
+    )
+    return null
+  })
+  if (!credentials) return null
+  if (!REPO_PATTERN.test(credentials.repo)) {
+    reportNonFatalError(
+      `[github-integration] GitHub repo must be "owner/repo"; got "${credentials.repo}"`,
+      new Error("invalid_repo"),
+      { once: true }
+    )
+    return null
+  }
+  return credentials
 }
 
 async function uploadAttachments(input: {

--- a/packages/bug-reports/src/lib/integrations.ts
+++ b/packages/bug-reports/src/lib/integrations.ts
@@ -1,8 +1,8 @@
+import { gunzipSync } from "node:zlib"
 import { db } from "@crikket/db"
 import { bugReport } from "@crikket/db/schema/bug-report"
 import { reportNonFatalError } from "@crikket/shared/lib/errors"
 import { eq } from "drizzle-orm"
-import { gunzipSync } from "node:zlib"
 import { getGithubIntegrationCredentials } from "./github-integration-config"
 import { getStorageProvider } from "./storage"
 
@@ -122,7 +122,10 @@ export async function forwardBugReportToGitHub(
       return
     }
 
-    const issue = (await response.json()) as { html_url?: string; number?: number }
+    const issue = (await response.json()) as {
+      html_url?: string
+      number?: number
+    }
     console.info(
       `[github-integration] Created GitHub issue #${issue.number ?? "?"} for bug report ${bugReportId}: ${issue.html_url ?? "(no url)"}`
     )
@@ -160,70 +163,84 @@ async function uploadAttachments(input: {
   }
 
   if (report.captureKey) {
-    const captureLabel =
-      report.attachmentType === "video" ? "Recording" : "Screenshot"
+    const captureKey = report.captureKey
     const captureFilename = filenameForCapture(report)
-    const result: AttachmentResult = {
-      kind: "capture",
-      label: captureLabel,
-      filename: captureFilename,
-    }
-    try {
-      const bytes = await storage.read(report.captureKey)
-      if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
-        result.tooLargeBytes = bytes.byteLength
-      } else if (await ensureBranch()) {
-        result.url = await uploadArtifact({
-          repo,
-          token,
-          branch: ATTACHMENTS_BRANCH,
-          path: `${report.id}/${captureFilename}`,
-          content: bytes,
-          message: `crikket: capture for bug report ${report.id}`,
-        })
-      } else {
-        result.error = "branch setup failed"
-      }
-    } catch (error) {
-      result.error = error instanceof Error ? error.message : String(error)
-    }
-    results.push(result)
+    results.push(
+      await uploadSingleAttachment({
+        kind: "capture",
+        label: report.attachmentType === "video" ? "Recording" : "Screenshot",
+        filename: captureFilename,
+        readBytes: () => storage.read(captureKey),
+        repo,
+        token,
+        reportId: report.id,
+        commitMessage: `crikket: capture for bug report ${report.id}`,
+        ensureBranch,
+      })
+    )
   }
 
   if (report.debuggerKey) {
+    const debuggerKey = report.debuggerKey
     const debuggerFilename = `${report.id}.debugger.json`
-    const result: AttachmentResult = {
-      kind: "debugger",
-      label: "Debugger payload",
-      filename: debuggerFilename,
-    }
-    try {
-      const raw = await storage.read(report.debuggerKey)
-      const bytes =
-        report.debuggerContentEncoding === "gzip"
-          ? Buffer.from(gunzipSync(raw))
-          : raw
-      if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
-        result.tooLargeBytes = bytes.byteLength
-      } else if (await ensureBranch()) {
-        result.url = await uploadArtifact({
-          repo,
-          token,
-          branch: ATTACHMENTS_BRANCH,
-          path: `${report.id}/${debuggerFilename}`,
-          content: bytes,
-          message: `crikket: debugger payload for bug report ${report.id}`,
-        })
-      } else {
-        result.error = "branch setup failed"
-      }
-    } catch (error) {
-      result.error = error instanceof Error ? error.message : String(error)
-    }
-    results.push(result)
+    const isGzipped = report.debuggerContentEncoding === "gzip"
+    results.push(
+      await uploadSingleAttachment({
+        kind: "debugger",
+        label: "Debugger payload",
+        filename: debuggerFilename,
+        readBytes: async () => {
+          const raw = await storage.read(debuggerKey)
+          return isGzipped ? Buffer.from(gunzipSync(raw)) : raw
+        },
+        repo,
+        token,
+        reportId: report.id,
+        commitMessage: `crikket: debugger payload for bug report ${report.id}`,
+        ensureBranch,
+      })
+    )
   }
 
   return results
+}
+
+async function uploadSingleAttachment(opts: {
+  kind: AttachmentKind
+  label: string
+  filename: string
+  readBytes: () => Promise<Buffer>
+  repo: string
+  token: string
+  reportId: string
+  commitMessage: string
+  ensureBranch: () => Promise<boolean>
+}): Promise<AttachmentResult> {
+  const result: AttachmentResult = {
+    kind: opts.kind,
+    label: opts.label,
+    filename: opts.filename,
+  }
+  try {
+    const bytes = await opts.readBytes()
+    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+      result.tooLargeBytes = bytes.byteLength
+    } else if (await opts.ensureBranch()) {
+      result.url = await uploadArtifact({
+        repo: opts.repo,
+        token: opts.token,
+        branch: ATTACHMENTS_BRANCH,
+        path: `${opts.reportId}/${opts.filename}`,
+        content: bytes,
+        message: opts.commitMessage,
+      })
+    } else {
+      result.error = "branch setup failed"
+    }
+  } catch (error) {
+    result.error = error instanceof Error ? error.message : String(error)
+  }
+  return result
 }
 
 async function ensureAttachmentsBranch(input: {
@@ -327,7 +344,7 @@ async function uploadArtifact(input: {
   return `https://github.com/${input.repo}/blob/${encodeURIComponent(input.branch)}/${encodePath(input.path)}`
 }
 
-async function ghFetch(
+function ghFetch(
   url: string,
   init: RequestInit & { token: string }
 ): Promise<Response> {
@@ -441,10 +458,7 @@ function renderIssueBody(input: {
   }
 
   if (report.actions.length > 0) {
-    sections.push(
-      "## Reproduction steps",
-      renderActionList(report.actions)
-    )
+    sections.push("## Reproduction steps", renderActionList(report.actions))
   }
 
   if (report.logs.length > 0) {
@@ -521,7 +535,10 @@ function renderNetworkTable(
     duration: number | null
   }>
 ): string {
-  const lines = ["| Method | Status | Duration | URL |", "| --- | --- | --- | --- |"]
+  const lines = [
+    "| Method | Status | Duration | URL |",
+    "| --- | --- | --- | --- |",
+  ]
   for (const row of rows) {
     lines.push(
       `| ${row.method} | ${row.status ?? "—"} | ${
@@ -537,7 +554,9 @@ function renderActionList(
 ): string {
   return actions
     .map((action, idx) => {
-      const target = action.target ? ` — \`${truncate(action.target, 120)}\`` : ""
+      const target = action.target
+        ? ` — \`${truncate(action.target, 120)}\``
+        : ""
       return `${idx + 1}. **${action.type}**${target}`
     })
     .join("\n")

--- a/packages/bug-reports/src/lib/storage.ts
+++ b/packages/bug-reports/src/lib/storage.ts
@@ -35,6 +35,7 @@ interface S3StorageOptions {
   bucket: string
   region: string
   endpoint?: string
+  publicEndpoint?: string
   addressingStyle?: S3AddressingStyle
   accessKeyId: string
   secretAccessKey: string
@@ -68,6 +69,27 @@ export function createS3StorageProvider(
     },
   })
 
+  // Second client used only for presigning URLs returned to the browser. When
+  // STORAGE_PUBLIC_ENDPOINT is set (e.g. local dev where the server reaches MinIO
+  // at http://minio:9000 but the browser must use http://localhost:9000), this
+  // ensures the signed Host matches what the browser will actually send.
+  const presignerClient = options.publicEndpoint
+    ? new S3Client({
+        region: options.region,
+        endpoint: options.publicEndpoint,
+        forcePathStyle: resolveS3ForcePathStyle({
+          endpoint: options.publicEndpoint,
+          addressingStyle: options.addressingStyle,
+        }),
+        requestChecksumCalculation: "WHEN_REQUIRED",
+        responseChecksumValidation: "WHEN_REQUIRED",
+        credentials: {
+          accessKeyId: options.accessKeyId,
+          secretAccessKey: options.secretAccessKey,
+        },
+      })
+    : client
+
   const getUrl = (filename: string): Promise<string> => {
     if (options.publicUrl) {
       return Promise.resolve(
@@ -76,7 +98,7 @@ export function createS3StorageProvider(
     }
 
     return getSignedUrl(
-      client,
+      presignerClient,
       new GetObjectCommand({
         Bucket: options.bucket,
         Key: filename,
@@ -129,7 +151,7 @@ export function createS3StorageProvider(
       }
 
       const url = await getSignedUrl(
-        client,
+        presignerClient,
         new PutObjectCommand({
           Bucket: options.bucket,
           Key: input.filename,
@@ -401,6 +423,7 @@ function getCloudStorageConfig(): S3StorageOptions {
     bucket,
     region,
     endpoint: env.STORAGE_ENDPOINT,
+    publicEndpoint: env.STORAGE_PUBLIC_ENDPOINT,
     addressingStyle: env.STORAGE_ADDRESSING_STYLE,
     accessKeyId,
     secretAccessKey,

--- a/packages/bug-reports/src/lib/upload-session.ts
+++ b/packages/bug-reports/src/lib/upload-session.ts
@@ -29,6 +29,7 @@ import {
   processBugReportIngestionJob,
   queueBugReportIngestionJob,
 } from "./ingestion-jobs"
+import { forwardBugReportToGitHub } from "./integrations"
 import { getStorageProvider } from "./storage"
 import {
   buildFallbackTitle,
@@ -395,6 +396,10 @@ export async function finalizeBugReportUpload(input: {
       message: "Failed to process debugger data for this report.",
     })
   }
+
+  // Fire-and-forget GitHub Issues forwarding. No-op unless GITHUB_ISSUES_* envs are set;
+  // errors are logged inside the helper and never block the capture response.
+  void forwardBugReportToGitHub(uploadSession.id)
 
   return {
     id: uploadSession.id,

--- a/packages/bug-reports/src/lib/upload-session.ts
+++ b/packages/bug-reports/src/lib/upload-session.ts
@@ -400,8 +400,11 @@ export async function finalizeBugReportUpload(input: {
   // Fire-and-forget GitHub Issues forwarding. No-op unless the report's
   // organization has a GitHub integration configured (Settings → Integrations
   // → GitHub). Errors are logged inside the helper and never block the
-  // capture response.
-  void forwardBugReportToGitHub(uploadSession.id)
+  // capture response — the .catch is only here to keep the unhandled-rejection
+  // linter happy; the helper swallows its own failures.
+  forwardBugReportToGitHub(uploadSession.id).catch(() => {
+    // intentional: errors are already reported inside the helper
+  })
 
   return {
     id: uploadSession.id,

--- a/packages/bug-reports/src/lib/upload-session.ts
+++ b/packages/bug-reports/src/lib/upload-session.ts
@@ -29,7 +29,7 @@ import {
   processBugReportIngestionJob,
   queueBugReportIngestionJob,
 } from "./ingestion-jobs"
-import { forwardBugReportToGitHub } from "./integrations"
+import { attachAndUpdateGitHubIssue, createGitHubIssue } from "./integrations"
 import { getStorageProvider } from "./storage"
 import {
   buildFallbackTitle,
@@ -251,6 +251,10 @@ export async function finalizeBugReportUpload(input: {
   id: string
   shareUrl: string
   warnings: string[]
+  // Populated when the org has a configured GitHub integration AND the
+  // synchronous Issues POST succeeded. Null otherwise — capture submit
+  // succeeds either way.
+  githubIssueUrl: string | null
 }> {
   const uploadSession = await db.query.bugReportUploadSession.findFirst({
     where: and(
@@ -268,6 +272,7 @@ export async function finalizeBugReportUpload(input: {
       columns: {
         id: true,
         submissionStatus: true,
+        githubIssueUrl: true,
       },
     })
 
@@ -286,6 +291,10 @@ export async function finalizeBugReportUpload(input: {
         id: existingReport.id,
         shareUrl: `/s/${existingReport.id}`,
         warnings: [],
+        // Idempotent re-finalize hits the existing row directly; surface the
+        // previously-persisted GitHub URL so a retried submit shows the same
+        // link the original submit did.
+        githubIssueUrl: existingReport.githubIssueUrl,
       }
     }
 
@@ -397,21 +406,52 @@ export async function finalizeBugReportUpload(input: {
     })
   }
 
-  // Fire-and-forget GitHub Issues forwarding. No-op unless the report's
-  // organization has a GitHub integration configured (Settings → Integrations
-  // → GitHub). Errors are logged inside the helper and never block the
-  // capture response — the .catch is only here to keep the unhandled-rejection
-  // linter happy; the helper swallows its own failures.
-  forwardBugReportToGitHub(uploadSession.id).catch(() => {
-    // intentional: errors are already reported inside the helper
-  })
+  const githubIssueUrl = await forwardToGithubAndPersist(uploadSession.id)
 
   return {
     id: uploadSession.id,
     shareUrl: `/s/${uploadSession.id}`,
     warnings,
     debugger: debuggerPersistence,
+    githubIssueUrl,
   }
+}
+
+/**
+ * Two-phase GitHub forwarding so the issue URL surfaces in the success modal.
+ *
+ * 1. createGitHubIssue is awaited: a single Issues POST (~hundreds of ms),
+ *    no attachments. Returns null fast when the org has no integration. The
+ *    URL is persisted on bug_report and returned so the SDK can render it
+ *    inline.
+ * 2. attachAndUpdateGitHubIssue is fire-and-forget: per-attachment Contents
+ *    API uploads + an issue PATCH to embed the links. Slow part — would
+ *    otherwise block capture-submit. The issue exists in the interim with an
+ *    attachment-free body.
+ *
+ * Both helpers swallow their own failures and report non-fatally.
+ */
+async function forwardToGithubAndPersist(
+  bugReportId: string
+): Promise<string | null> {
+  const created = await createGitHubIssue(bugReportId)
+  if (!created) return null
+
+  await db
+    .update(bugReport)
+    .set({ githubIssueUrl: created.htmlUrl, updatedAt: new Date() })
+    .where(eq(bugReport.id, bugReportId))
+
+  attachAndUpdateGitHubIssue({
+    bugReportId,
+    issueNumber: created.number,
+    repo: created.repo,
+    token: created.token,
+  }).catch(() => {
+    // intentional: errors are already reported inside the helper
+  })
+
+  return created.htmlUrl
 }
 
 async function finalizeBugReportDebuggerIngestion(input: {

--- a/packages/bug-reports/src/lib/upload-session.ts
+++ b/packages/bug-reports/src/lib/upload-session.ts
@@ -397,8 +397,10 @@ export async function finalizeBugReportUpload(input: {
     })
   }
 
-  // Fire-and-forget GitHub Issues forwarding. No-op unless GITHUB_ISSUES_* envs are set;
-  // errors are logged inside the helper and never block the capture response.
+  // Fire-and-forget GitHub Issues forwarding. No-op unless the report's
+  // organization has a GitHub integration configured (Settings → Integrations
+  // → GitHub). Errors are logged inside the helper and never block the
+  // capture response.
   void forwardBugReportToGitHub(uploadSession.id)
 
   return {

--- a/packages/bug-reports/src/procedures/get-bug-report.ts
+++ b/packages/bug-reports/src/procedures/get-bug-report.ts
@@ -68,6 +68,9 @@ export const getBugReportById = o
       priority,
       tags: Array.isArray(report.tags) ? report.tags : [],
       url: report.url,
+      // Surfaced on the bug-report detail page so admins can jump from the
+      // capture to the GitHub issue created for it.
+      githubIssueUrl: report.githubIssueUrl,
       attachmentUrl,
       attachmentType: report.attachmentType,
       submissionStatus: report.submissionStatus,

--- a/packages/bug-reports/src/procedures/github-integration.ts
+++ b/packages/bug-reports/src/procedures/github-integration.ts
@@ -19,17 +19,21 @@ const upsertInputSchema = z.object({
   token: z.string().optional(),
 })
 
-export const getIntegration = protectedProcedure.handler(async ({ context }) => {
-  const organizationId = await requireActiveOrgAdmin(context.session)
-  return getGithubIntegrationSummary(organizationId)
-})
+export const getIntegration = protectedProcedure.handler(
+  async ({ context }) => {
+    const organizationId = await requireActiveOrgAdmin(context.session)
+    return getGithubIntegrationSummary(organizationId)
+  }
+)
 
 export const upsertIntegration = protectedProcedure
   .input(upsertInputSchema)
   .handler(async ({ context, input }) => {
     const organizationId = await requireActiveOrgAdmin(context.session)
     const trimmedToken =
-      input.token && input.token.trim().length > 0 ? input.token.trim() : undefined
+      input.token && input.token.trim().length > 0
+        ? input.token.trim()
+        : undefined
 
     try {
       await upsertGithubIntegration({

--- a/packages/bug-reports/src/procedures/github-integration.ts
+++ b/packages/bug-reports/src/procedures/github-integration.ts
@@ -1,0 +1,57 @@
+import { ORPCError } from "@orpc/server"
+import { z } from "zod"
+import {
+  deleteGithubIntegration,
+  getGithubIntegrationSummary,
+  upsertGithubIntegration,
+} from "../lib/github-integration-config"
+import { protectedProcedure } from "./context"
+import { requireActiveOrgAdmin } from "./helpers"
+
+const repoSchema = z
+  .string()
+  .trim()
+  .regex(/^[^/\s]+\/[^/\s]+$/, { message: "Expected owner/repo" })
+
+const upsertInputSchema = z.object({
+  repo: repoSchema,
+  // Empty string = "don't change the stored token". Non-empty = replace.
+  token: z.string().optional(),
+})
+
+export const getIntegration = protectedProcedure.handler(async ({ context }) => {
+  const organizationId = await requireActiveOrgAdmin(context.session)
+  return getGithubIntegrationSummary(organizationId)
+})
+
+export const upsertIntegration = protectedProcedure
+  .input(upsertInputSchema)
+  .handler(async ({ context, input }) => {
+    const organizationId = await requireActiveOrgAdmin(context.session)
+    const trimmedToken =
+      input.token && input.token.trim().length > 0 ? input.token.trim() : undefined
+
+    try {
+      await upsertGithubIntegration({
+        organizationId,
+        repo: input.repo,
+        token: trimmedToken,
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to save GitHub integration."
+      throw new ORPCError("BAD_REQUEST", { message })
+    }
+
+    return getGithubIntegrationSummary(organizationId)
+  })
+
+export const removeIntegration = protectedProcedure.handler(
+  async ({ context }) => {
+    const organizationId = await requireActiveOrgAdmin(context.session)
+    await deleteGithubIntegration(organizationId)
+    return { ok: true }
+  }
+)

--- a/packages/bug-reports/test/crypto.test.ts
+++ b/packages/bug-reports/test/crypto.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test"
+import { decryptSecret, encryptSecret } from "@crikket/shared/lib/server/crypto"
+
+const SECRET = "0123456789abcdef0123456789abcdef"
+const SHORT_SECRET_RE = /at least 32/i
+const TOO_SHORT_RE = /too short/i
+
+describe("encryptSecret / decryptSecret", () => {
+  it("round-trips a plaintext through encrypt then decrypt", () => {
+    const plaintext = "ghp_abcdef0123456789"
+    const blob = encryptSecret(plaintext, SECRET)
+    expect(decryptSecret(blob, SECRET)).toBe(plaintext)
+  })
+
+  it("produces different ciphertexts for the same plaintext (random IV)", () => {
+    const plaintext = "ghp_abcdef0123456789"
+    const a = encryptSecret(plaintext, SECRET)
+    const b = encryptSecret(plaintext, SECRET)
+    expect(a).not.toBe(b)
+    // Both still decrypt to the same value.
+    expect(decryptSecret(a, SECRET)).toBe(plaintext)
+    expect(decryptSecret(b, SECRET)).toBe(plaintext)
+  })
+
+  it("fails to decrypt when the key is wrong", () => {
+    const blob = encryptSecret("ghp_abcdef", SECRET)
+    const wrongSecret = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+    expect(() => decryptSecret(blob, wrongSecret)).toThrow()
+  })
+
+  it("rejects secrets shorter than 32 characters", () => {
+    expect(() => encryptSecret("payload", "short")).toThrow(SHORT_SECRET_RE)
+    // Same rule applies on decrypt since it calls deriveKey.
+    const blob = encryptSecret("payload", SECRET)
+    expect(() => decryptSecret(blob, "short")).toThrow(SHORT_SECRET_RE)
+  })
+
+  it("rejects malformed encrypted blobs", () => {
+    expect(() => decryptSecret("not-base64-at-all!!", SECRET)).toThrow()
+    // Valid base64 but too short to contain IV + auth tag + 1 byte of ciphertext.
+    const tooShort = Buffer.from("abcd").toString("base64")
+    expect(() => decryptSecret(tooShort, SECRET)).toThrow(TOO_SHORT_RE)
+  })
+
+  it("fails when the ciphertext has been tampered with (auth tag check)", () => {
+    const blob = encryptSecret("ghp_abcdef", SECRET)
+    // Overwrite one byte in the middle of the ciphertext with a different value.
+    const buf = Buffer.from(blob, "base64")
+    const idx = buf.length - 20
+    const original = buf[idx] ?? 0
+    buf[idx] = original === 0x42 ? 0x43 : 0x42
+    const tampered = buf.toString("base64")
+    expect(() => decryptSecret(tampered, SECRET)).toThrow()
+  })
+})

--- a/packages/bug-reports/test/integrations.test.ts
+++ b/packages/bug-reports/test/integrations.test.ts
@@ -206,9 +206,15 @@ afterAll(() => {
 // ----- Module under test ----------------------------------------------------
 
 let forwardBugReportToGitHub: typeof import("../src/lib/integrations").forwardBugReportToGitHub
+let createGitHubIssue: typeof import("../src/lib/integrations").createGitHubIssue
+let attachAndUpdateGitHubIssue: typeof import("../src/lib/integrations").attachAndUpdateGitHubIssue
 
 beforeAll(async () => {
-  ;({ forwardBugReportToGitHub } = await import("../src/lib/integrations"))
+  ;({
+    forwardBugReportToGitHub,
+    createGitHubIssue,
+    attachAndUpdateGitHubIssue,
+  } = await import("../src/lib/integrations"))
 })
 
 // ----- Helpers --------------------------------------------------------------
@@ -299,6 +305,19 @@ function lastIssuePost(): RecordedCall | undefined {
   return [...fetchCalls]
     .reverse()
     .find((c) => c.method === "POST" && c.url.endsWith("/issues"))
+}
+
+const ISSUE_PATCH_URL_RE = /\/issues\/\d+$/
+const ISSUE_42_PATCH_URL_RE = /\/issues\/42$/
+
+// After the create/attach split, attachments + size notices land in a PATCH
+// to /issues/<n> (the followup that embeds artifact links), not in the
+// initial POST /issues body. Tests asserting on attachment markdown should
+// inspect this call instead of lastIssuePost.
+function lastIssuePatch(): RecordedCall | undefined {
+  return [...fetchCalls]
+    .reverse()
+    .find((c) => c.method === "PATCH" && ISSUE_PATCH_URL_RE.test(c.url))
 }
 
 beforeEach(() => {
@@ -394,7 +413,10 @@ describe("forwardBugReportToGitHub: issue body rendering", () => {
   it("renders artifact links using github.com/<repo>/blob URLs and no inline embed", async () => {
     await forwardBugReportToGitHub(state.report!.id)
 
-    const bodyText = (lastIssuePost()!.body as { body: string }).body
+    // Attachment links land in the PATCH that updates the body after uploads,
+    // not in the initial create POST (which goes out before attachments are
+    // touched so the issue URL can be returned to the SDK quickly).
+    const bodyText = (lastIssuePatch()!.body as { body: string }).body
 
     // Uses blob URL, not raw.githubusercontent.com
     expect(bodyText).toContain(
@@ -407,6 +429,11 @@ describe("forwardBugReportToGitHub: issue body rendering", () => {
 
     // No inline screenshot embed (Camo would refuse private-repo content).
     expect(bodyText).not.toContain("![Screenshot]")
+
+    // The original POST should NOT contain the artifact links — they only
+    // appear after the upload phase finishes and PATCHes the body.
+    const initialBody = (lastIssuePost()!.body as { body: string }).body
+    expect(initialBody).not.toContain("/blob/crikket-attachments/")
   })
 
   it("renders reproduction steps, console logs, and a network table", async () => {
@@ -533,7 +560,10 @@ describe("forwardBugReportToGitHub: attachment branch + upload flow", () => {
     )
     expect(capturePuts.length).toBe(0)
 
-    const bodyText = (lastIssuePost()!.body as { body: string }).body
+    // The "not uploaded" notice is part of the attachments section, which
+    // only gets rendered into the PATCH body — the initial create POST goes
+    // out before attachments are processed.
+    const bodyText = (lastIssuePatch()!.body as { body: string }).body
     expect(bodyText).toContain("not uploaded")
     expect(bodyText).toContain("MB exceeds")
     expect(bodyText).toContain("Retrieve from crikket")
@@ -553,5 +583,62 @@ describe("forwardBugReportToGitHub: issue creation failure", () => {
     expect(
       state.nonFatalErrors.some((e) => ISSUE_CREATE_FAILED_RE.test(e.message))
     ).toBeTrue()
+  })
+})
+
+// The two-phase split exists so upload-session can await issue creation
+// (fast) and surface the URL synchronously, while the slow attachment
+// uploads + body PATCH stay fire-and-forget. These tests pin that contract.
+describe("createGitHubIssue / attachAndUpdateGitHubIssue split", () => {
+  beforeEach(() => {
+    state.report = makeReport()
+    state.credentials = { repo: "owner/repo", token: "ghp_x" }
+  })
+
+  it("createGitHubIssue returns the issue URL + number without uploading attachments", async () => {
+    const created = await createGitHubIssue(state.report!.id)
+
+    expect(created).not.toBeNull()
+    expect(created!.htmlUrl).toBe("https://github.com/test/repo/issues/42")
+    expect(created!.number).toBe(42)
+
+    // No attachment uploads should have happened — the contract is "fast,
+    // single POST". Branch ensure + Contents API PUTs belong to the second
+    // phase.
+    const attachmentWrites = fetchCalls.filter(
+      (c) => c.method === "PUT" && c.url.includes("/contents/")
+    )
+    expect(attachmentWrites.length).toBe(0)
+
+    // Initial body has no attachment markdown.
+    const initialBody = (lastIssuePost()!.body as { body: string }).body
+    expect(initialBody).not.toContain("/blob/crikket-attachments/")
+    expect(initialBody).not.toContain("## Artifacts")
+  })
+
+  it("createGitHubIssue returns null when the org has no GitHub integration", async () => {
+    state.credentials = null
+
+    const created = await createGitHubIssue(state.report!.id)
+
+    expect(created).toBeNull()
+    // No POST /issues either — we bail before hitting the API.
+    expect(lastIssuePost()).toBeUndefined()
+  })
+
+  it("attachAndUpdateGitHubIssue uploads attachments and PATCHes the issue body", async () => {
+    state.branchExists = true
+
+    await attachAndUpdateGitHubIssue({
+      bugReportId: state.report!.id,
+      issueNumber: 42,
+      repo: "owner/repo",
+      token: "ghp_x",
+    })
+
+    const patchedBody = (lastIssuePatch()!.body as { body: string }).body
+    expect(patchedBody).toContain("## Artifacts")
+    expect(patchedBody).toContain("/blob/crikket-attachments/")
+    expect(lastIssuePatch()!.url).toMatch(ISSUE_42_PATCH_URL_RE)
   })
 })

--- a/packages/bug-reports/test/integrations.test.ts
+++ b/packages/bug-reports/test/integrations.test.ts
@@ -1,0 +1,557 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test"
+
+// ----- Mutable state wired into the module-level mocks below ---------------
+
+type Report = {
+  id: string
+  organizationId: string
+  title: string | null
+  description: string | null
+  priority: string
+  url: string | null
+  status: string
+  tags: string[] | null
+  attachmentType: string | null
+  deviceInfo: unknown
+  metadata: unknown
+  createdAt: Date
+  captureKey: string | null
+  debuggerKey: string | null
+  debuggerContentEncoding: string | null
+  logs: Array<{ level: string; message: string; timestamp: Date }>
+  networkRequests: Array<{
+    method: string
+    url: string
+    status: number | null
+    duration: number | null
+    timestamp: Date
+  }>
+  actions: Array<{ type: string; target: string | null; timestamp: Date }>
+}
+
+const state: {
+  report: Report | null
+  credentials: { repo: string; token: string } | null
+  captureBytes: Buffer | null
+  debuggerBytes: Buffer | null
+  // Fetch-side state
+  branchExists: boolean
+  branchCreateStatus: number
+  existingFileSha: string | undefined
+  issueStatus: number
+  issueResponse: { number?: number; html_url?: string }
+  nonFatalErrors: Array<{ message: string; error: unknown }>
+} = {
+  report: null,
+  credentials: null,
+  captureBytes: null,
+  debuggerBytes: null,
+  branchExists: false,
+  branchCreateStatus: 201,
+  existingFileSha: undefined,
+  issueStatus: 201,
+  issueResponse: {
+    number: 42,
+    html_url: "https://github.com/test/repo/issues/42",
+  },
+  nonFatalErrors: [],
+}
+
+mock.module("@crikket/env/server", () => ({
+  env: {
+    DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/crikket",
+    BETTER_AUTH_SECRET: "0123456789abcdef0123456789abcdef",
+    BETTER_AUTH_URL: "http://localhost:3000",
+    STORAGE_BUCKET: "bug-report-bucket",
+    STORAGE_REGION: "us-east-1",
+    STORAGE_ENDPOINT: "https://s3.us-east-1.amazonaws.com",
+    STORAGE_ACCESS_KEY_ID: "access",
+    STORAGE_SECRET_ACCESS_KEY: "secret",
+  },
+}))
+
+mock.module("@crikket/db", () => ({
+  db: {
+    query: {
+      bugReport: {
+        findFirst: () => Promise.resolve(state.report),
+      },
+      bugReportArtifactCleanup: {
+        findMany: () => Promise.resolve([]),
+        findFirst: () => Promise.resolve(null),
+      },
+    },
+  },
+}))
+
+mock.module("@crikket/shared/lib/errors", () => ({
+  reportNonFatalError: (message: string, error: unknown) => {
+    state.nonFatalErrors.push({ message, error })
+  },
+}))
+
+mock.module("../src/lib/github-integration-config", () => ({
+  getGithubIntegrationCredentials: () => Promise.resolve(state.credentials),
+}))
+
+mock.module("../src/lib/storage", () => ({
+  getStorageProvider: () => ({
+    read: (key: string): Promise<Buffer> => {
+      if (state.report?.captureKey && key === state.report.captureKey) {
+        return Promise.resolve(state.captureBytes ?? Buffer.alloc(0))
+      }
+      if (state.report?.debuggerKey && key === state.report.debuggerKey) {
+        return Promise.resolve(state.debuggerBytes ?? Buffer.alloc(0))
+      }
+      return Promise.reject(new Error(`unknown storage key: ${key}`))
+    },
+  }),
+  // Used by signed-url tests; included to keep the module shape complete.
+  isExpiringSignedUrl: () => false,
+}))
+
+// ----- Fetch mock -----------------------------------------------------------
+
+interface RecordedCall {
+  url: string
+  method: string
+  body?: unknown
+}
+
+const fetchCalls: RecordedCall[] = []
+
+const REPO_ROOT_RE = /\/repos\/[^/]+\/[^/]+$/
+const NOT_FOUND_RE = /not found/i
+const OWNER_REPO_RE = /owner\/repo/i
+const ISSUE_CREATE_FAILED_RE = /Failed to create GitHub issue/i
+
+function jsonResponse(status: number, body: unknown): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+  )
+}
+
+const originalFetch = globalThis.fetch
+globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+  const u =
+    typeof url === "string"
+      ? url
+      : url instanceof URL
+        ? url.toString()
+        : url.url
+  const method = (init?.method ?? "GET").toUpperCase()
+  let body: unknown
+  if (init?.body && typeof init.body === "string") {
+    try {
+      body = JSON.parse(init.body)
+    } catch {
+      body = init.body
+    }
+  }
+  fetchCalls.push({ url: u, method, body })
+
+  // Branch check
+  if (method === "GET" && u.includes("/branches/")) {
+    return state.branchExists
+      ? jsonResponse(200, { name: "crikket-attachments" })
+      : jsonResponse(404, { message: "Branch not found" })
+  }
+  // Get repo info (for default_branch)
+  if (method === "GET" && REPO_ROOT_RE.test(u)) {
+    return jsonResponse(200, { default_branch: "main" })
+  }
+  // Get ref for default branch
+  if (method === "GET" && u.includes("/git/ref/heads/")) {
+    return jsonResponse(200, { object: { sha: "defaultsha1234" } })
+  }
+  // Create ref
+  if (method === "POST" && u.includes("/git/refs")) {
+    return jsonResponse(state.branchCreateStatus, {})
+  }
+  // Contents GET — existing sha check
+  if (method === "GET" && u.includes("/contents/")) {
+    if (state.existingFileSha) {
+      return jsonResponse(200, { sha: state.existingFileSha })
+    }
+    return jsonResponse(404, {})
+  }
+  // Contents PUT — upload
+  if (method === "PUT" && u.includes("/contents/")) {
+    return jsonResponse(200, {})
+  }
+  // Create issue
+  if (method === "POST" && u.includes("/issues")) {
+    return jsonResponse(state.issueStatus, state.issueResponse)
+  }
+  return Promise.reject(new Error(`Unhandled fetch: ${method} ${u}`))
+}) as typeof fetch
+
+afterAll(() => {
+  globalThis.fetch = originalFetch
+  mock.restore()
+})
+
+// ----- Module under test ----------------------------------------------------
+
+let forwardBugReportToGitHub: typeof import("../src/lib/integrations").forwardBugReportToGitHub
+
+beforeAll(async () => {
+  ;({ forwardBugReportToGitHub } = await import("../src/lib/integrations"))
+})
+
+// ----- Helpers --------------------------------------------------------------
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    id: "br_abc123",
+    organizationId: "org_test",
+    title: "Button does not submit",
+    description: "Clicking Save does nothing on the settings page.",
+    priority: "high",
+    url: "https://app.example.com/settings",
+    status: "new",
+    tags: ["settings", "regression"],
+    attachmentType: "screenshot",
+    deviceInfo: {
+      browser: "Chrome 131",
+      os: "macOS",
+      viewport: "1440x900",
+    },
+    metadata: {
+      duration: "2s",
+      durationMs: 2000,
+      sdkVersion: "1.0.0",
+      submittedVia: "widget",
+    },
+    createdAt: new Date("2026-04-22T16:00:00Z"),
+    captureKey:
+      "organizations/org_test/bug-reports/br_abc123/capture/screenshot.png",
+    debuggerKey:
+      "organizations/org_test/bug-reports/br_abc123/debugger/payload.json.gz",
+    debuggerContentEncoding: null,
+    logs: [
+      {
+        level: "error",
+        message: "Uncaught TypeError: cannot read properties of undefined",
+        timestamp: new Date("2026-04-22T16:00:01Z"),
+      },
+      {
+        level: "warn",
+        message: "Deprecated API usage",
+        timestamp: new Date("2026-04-22T16:00:02Z"),
+      },
+    ],
+    networkRequests: [
+      {
+        method: "POST",
+        url: "https://api.example.com/v1/settings",
+        status: 500,
+        duration: 423,
+        timestamp: new Date("2026-04-22T16:00:03Z"),
+      },
+    ],
+    actions: [
+      {
+        type: "click",
+        target: "button#save",
+        timestamp: new Date("2026-04-22T16:00:00Z"),
+      },
+      {
+        type: "input",
+        target: "input#email",
+        timestamp: new Date("2026-04-22T16:00:00.500Z"),
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function resetState(): void {
+  state.report = null
+  state.credentials = null
+  state.captureBytes = null
+  state.debuggerBytes = null
+  state.branchExists = false
+  state.branchCreateStatus = 201
+  state.existingFileSha = undefined
+  state.issueStatus = 201
+  state.issueResponse = {
+    number: 42,
+    html_url: "https://github.com/test/repo/issues/42",
+  }
+  state.nonFatalErrors = []
+  fetchCalls.length = 0
+}
+
+function lastIssuePost(): RecordedCall | undefined {
+  return [...fetchCalls]
+    .reverse()
+    .find((c) => c.method === "POST" && c.url.endsWith("/issues"))
+}
+
+beforeEach(() => {
+  resetState()
+})
+afterEach(() => {
+  resetState()
+})
+
+// ----- Tests ----------------------------------------------------------------
+
+describe("forwardBugReportToGitHub: guard rails", () => {
+  it("returns early when the report does not exist", async () => {
+    state.report = null
+    state.credentials = { repo: "owner/repo", token: "ghp_x" }
+
+    await forwardBugReportToGitHub("br_missing")
+
+    // No GitHub calls should fire if the report wasn't found.
+    const githubCalls = fetchCalls.filter((c) =>
+      c.url.includes("api.github.com")
+    )
+    expect(githubCalls.length).toBe(0)
+    expect(
+      state.nonFatalErrors.some((e) => NOT_FOUND_RE.test(e.message))
+    ).toBeTrue()
+  })
+
+  it("returns early when no credentials are configured for the org", async () => {
+    state.report = makeReport({ captureKey: null, debuggerKey: null })
+    state.credentials = null
+
+    await forwardBugReportToGitHub(state.report.id)
+
+    const githubCalls = fetchCalls.filter((c) =>
+      c.url.includes("api.github.com")
+    )
+    expect(githubCalls.length).toBe(0)
+  })
+
+  it("reports a non-fatal error and returns when repo is malformed", async () => {
+    state.report = makeReport({ captureKey: null, debuggerKey: null })
+    state.credentials = { repo: "not-a-valid-repo", token: "ghp_x" }
+
+    await forwardBugReportToGitHub(state.report.id)
+
+    const githubCalls = fetchCalls.filter((c) =>
+      c.url.includes("api.github.com")
+    )
+    expect(githubCalls.length).toBe(0)
+    expect(
+      state.nonFatalErrors.some((e) => OWNER_REPO_RE.test(e.message))
+    ).toBeTrue()
+  })
+})
+
+describe("forwardBugReportToGitHub: issue body rendering", () => {
+  beforeEach(() => {
+    state.report = makeReport()
+    state.credentials = { repo: "owner/repo", token: "ghp_x" }
+    state.captureBytes = Buffer.from("fake-png-bytes")
+    state.debuggerBytes = Buffer.from(
+      JSON.stringify({ actions: [], logs: [], networkRequests: [] })
+    )
+    state.branchExists = true
+  })
+
+  it("builds title, labels, and description from the report", async () => {
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const post = lastIssuePost()
+    expect(post).toBeDefined()
+    const body = post!.body as { title: string; labels: string[]; body: string }
+
+    expect(body.title).toBe("[crikket] Button does not submit")
+    expect(body.labels).toEqual(["crikket", "priority:high"])
+    expect(body.body).toContain("## Description")
+    expect(body.body).toContain("Clicking Save does nothing")
+  })
+
+  it("emits the Context table with device, URL, and tag fields", async () => {
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const bodyText = (lastIssuePost()!.body as { body: string }).body
+    expect(bodyText).toContain("## Context")
+    expect(bodyText).toContain("| URL | https://app.example.com/settings |")
+    expect(bodyText).toContain("| Browser | Chrome 131 |")
+    expect(bodyText).toContain("| OS | macOS |")
+    expect(bodyText).toContain("| Priority | high |")
+    expect(bodyText).toContain("| Tags | settings, regression |")
+  })
+
+  it("renders artifact links using github.com/<repo>/blob URLs and no inline embed", async () => {
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const bodyText = (lastIssuePost()!.body as { body: string }).body
+
+    // Uses blob URL, not raw.githubusercontent.com
+    expect(bodyText).toContain(
+      "https://github.com/owner/repo/blob/crikket-attachments/br_abc123/br_abc123.png"
+    )
+    expect(bodyText).toContain(
+      "https://github.com/owner/repo/blob/crikket-attachments/br_abc123/br_abc123.debugger.json"
+    )
+    expect(bodyText).not.toContain("raw.githubusercontent.com")
+
+    // No inline screenshot embed (Camo would refuse private-repo content).
+    expect(bodyText).not.toContain("![Screenshot]")
+  })
+
+  it("renders reproduction steps, console logs, and a network table", async () => {
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const bodyText = (lastIssuePost()!.body as { body: string }).body
+    expect(bodyText).toContain("## Reproduction steps")
+    expect(bodyText).toContain("1. **click** — `button#save`")
+    expect(bodyText).toContain("2. **input**")
+
+    expect(bodyText).toContain("## Console logs")
+    expect(bodyText).toContain("ERROR: Uncaught TypeError")
+
+    expect(bodyText).toContain("<summary>Network requests</summary>")
+    expect(bodyText).toContain("| POST | 500 | 423ms |")
+  })
+
+  it("omits the priority label when priority is 'none'", async () => {
+    state.report = makeReport({ priority: "none" })
+
+    await forwardBugReportToGitHub(state.report.id)
+
+    const labels = (lastIssuePost()!.body as { labels: string[] }).labels
+    expect(labels).toEqual(["crikket"])
+  })
+
+  it("falls back to the URL in the title when description has no title", async () => {
+    state.report = makeReport({ title: null })
+
+    await forwardBugReportToGitHub(state.report.id)
+
+    const title = (lastIssuePost()!.body as { title: string }).title
+    expect(title).toBe(
+      "[crikket] Bug report from https://app.example.com/settings"
+    )
+  })
+})
+
+describe("forwardBugReportToGitHub: attachment branch + upload flow", () => {
+  beforeEach(() => {
+    state.report = makeReport()
+    state.credentials = { repo: "owner/repo", token: "ghp_x" }
+    state.captureBytes = Buffer.from("fake-png")
+    state.debuggerBytes = Buffer.from("{}")
+  })
+
+  it("creates the attachments branch when it does not exist", async () => {
+    state.branchExists = false
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    // Should have fetched repo info, default ref, and POSTed to /git/refs.
+    const createRef = fetchCalls.find(
+      (c) => c.method === "POST" && c.url.endsWith("/git/refs")
+    )
+    expect(createRef).toBeDefined()
+    const body = createRef!.body as { ref: string; sha: string }
+    expect(body.ref).toBe("refs/heads/crikket-attachments")
+    expect(body.sha).toBe("defaultsha1234")
+  })
+
+  it("is idempotent when branch creation returns 422 (race condition)", async () => {
+    state.branchExists = false
+    state.branchCreateStatus = 422
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    // Issue is still created despite the 422 on the ref create.
+    const post = lastIssuePost()
+    expect(post).toBeDefined()
+  })
+
+  it("skips branch creation when the branch already exists", async () => {
+    state.branchExists = true
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const createRef = fetchCalls.find(
+      (c) => c.method === "POST" && c.url.endsWith("/git/refs")
+    )
+    expect(createRef).toBeUndefined()
+  })
+
+  it("includes the existing file sha when overwriting an uploaded artifact", async () => {
+    state.branchExists = true
+    state.existingFileSha = "existing-blob-sha"
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const puts = fetchCalls.filter((c) => c.method === "PUT")
+    expect(puts.length).toBe(2) // capture + debugger
+    for (const put of puts) {
+      const body = put.body as { sha?: string; content: string; branch: string }
+      expect(body.sha).toBe("existing-blob-sha")
+      expect(body.branch).toBe("crikket-attachments")
+      // Content is base64-encoded.
+      expect(() => Buffer.from(body.content, "base64")).not.toThrow()
+    }
+  })
+
+  it("omits the sha when no existing file is present (create)", async () => {
+    state.branchExists = true
+    state.existingFileSha = undefined
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    const puts = fetchCalls.filter((c) => c.method === "PUT")
+    for (const put of puts) {
+      const body = put.body as { sha?: string }
+      expect(body.sha).toBeUndefined()
+    }
+  })
+
+  it("skips upload for oversize artifacts and renders a size notice", async () => {
+    state.branchExists = true
+    state.captureBytes = Buffer.alloc(41 * 1024 * 1024) // 41 MB > 40 MB cap
+    state.debuggerBytes = Buffer.from("{}")
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    // No PUT for the oversize capture.
+    const capturePuts = fetchCalls.filter(
+      (c) => c.method === "PUT" && c.url.includes("br_abc123.png")
+    )
+    expect(capturePuts.length).toBe(0)
+
+    const bodyText = (lastIssuePost()!.body as { body: string }).body
+    expect(bodyText).toContain("not uploaded")
+    expect(bodyText).toContain("MB exceeds")
+    expect(bodyText).toContain("Retrieve from crikket")
+  })
+})
+
+describe("forwardBugReportToGitHub: issue creation failure", () => {
+  it("reports a non-fatal error and does not throw when POST /issues fails", async () => {
+    state.report = makeReport({ captureKey: null, debuggerKey: null })
+    state.credentials = { repo: "owner/repo", token: "ghp_x" }
+    state.branchExists = true
+    state.issueStatus = 500
+    state.issueResponse = { number: undefined, html_url: undefined }
+
+    await forwardBugReportToGitHub(state.report!.id)
+
+    expect(
+      state.nonFatalErrors.some((e) => ISSUE_CREATE_FAILED_RE.test(e.message))
+    ).toBeTrue()
+  })
+})

--- a/packages/db/src/migrations/0001_military_black_tom.sql
+++ b/packages/db/src/migrations/0001_military_black_tom.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "organization_github_integration" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"repo" text NOT NULL,
+	"token_encrypted" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organization_github_integration" ADD CONSTRAINT "organization_github_integration_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "org_github_integration_organizationId_idx" ON "organization_github_integration" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "org_github_integration_organizationId_unique" ON "organization_github_integration" USING btree ("organization_id");

--- a/packages/db/src/migrations/0002_add_bug_report_github_issue_url.sql
+++ b/packages/db/src/migrations/0002_add_bug_report_github_issue_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "bug_report" ADD COLUMN "github_issue_url" text;

--- a/packages/db/src/migrations/meta/0001_snapshot.json
+++ b/packages/db/src/migrations/meta/0001_snapshot.json
@@ -1,0 +1,2352 @@
+{
+  "id": "c8bea055-b892-47d9-b753-841d7446260b",
+  "prevId": "8b565d21-a8a7-41cd-b651-4faf194a7a04",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organization_github_integration": {
+      "name": "organization_github_integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_github_integration_organizationId_idx": {
+          "name": "org_github_integration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_github_integration_organizationId_unique": {
+          "name": "org_github_integration_organizationId_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_github_integration_organization_id_organization_id_fk": {
+          "name": "organization_github_integration_organization_id_organization_id_fk",
+          "tableFrom": "organization_github_integration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report": {
+      "name": "bug_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_key": {
+          "name": "capture_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_content_type": {
+          "name": "capture_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_size_bytes": {
+          "name": "capture_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_uploaded_at": {
+          "name": "capture_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_content_type": {
+          "name": "thumbnail_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_key": {
+          "name": "debugger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_content_encoding": {
+          "name": "debugger_content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_size_bytes": {
+          "name": "debugger_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_uploaded_at": {
+          "name": "debugger_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_ingestion_status": {
+          "name": "debugger_ingestion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "debugger_ingestion_error": {
+          "name": "debugger_ingestion_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_ingested_at": {
+          "name": "debugger_ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_organizationId_idx": {
+          "name": "bug_report_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_reporterId_idx": {
+          "name": "bug_report_reporterId_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_submissionStatus_idx": {
+          "name": "bug_report_submissionStatus_idx",
+          "columns": [
+            {
+              "expression": "submission_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_debuggerIngestionStatus_idx": {
+          "name": "bug_report_debuggerIngestionStatus_idx",
+          "columns": [
+            {
+              "expression": "debugger_ingestion_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_organization_id_organization_id_fk": {
+          "name": "bug_report_organization_id_organization_id_fk",
+          "tableFrom": "bug_report",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bug_report_reporter_id_user_id_fk": {
+          "name": "bug_report_reporter_id_user_id_fk",
+          "tableFrom": "bug_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_action": {
+      "name": "bug_report_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bug_report_action_bugReportId_idx": {
+          "name": "bug_report_action_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_action_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_action_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_action",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_artifact_cleanup": {
+      "name": "bug_report_artifact_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_kind": {
+          "name": "artifact_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_artifact_cleanup_nextAttemptAt_idx": {
+          "name": "bug_report_artifact_cleanup_nextAttemptAt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bug_report_artifact_cleanup_object_key_unique": {
+          "name": "bug_report_artifact_cleanup_object_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_ingestion_job": {
+      "name": "bug_report_ingestion_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_ingestion_job_bugReportId_idx": {
+          "name": "bug_report_ingestion_job_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_ingestion_job_status_idx": {
+          "name": "bug_report_ingestion_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_ingestion_job_nextAttemptAt_idx": {
+          "name": "bug_report_ingestion_job_nextAttemptAt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_ingestion_job_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_ingestion_job_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_ingestion_job",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bug_report_ingestion_job_organization_id_organization_id_fk": {
+          "name": "bug_report_ingestion_job_organization_id_organization_id_fk",
+          "tableFrom": "bug_report_ingestion_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_log": {
+      "name": "bug_report_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bug_report_log_bugReportId_idx": {
+          "name": "bug_report_log_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_log_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_log_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_log",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_network_request": {
+      "name": "bug_report_network_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bug_report_network_request_bugReportId_idx": {
+          "name": "bug_report_network_request_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_network_request_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_network_request_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_network_request",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_upload_session": {
+      "name": "bug_report_upload_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "capture_key": {
+          "name": "capture_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_content_type": {
+          "name": "capture_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debugger_key": {
+          "name": "debugger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_upload_session_organizationId_idx": {
+          "name": "bug_report_upload_session_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_upload_session_expiresAt_idx": {
+          "name": "bug_report_upload_session_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_upload_session_organization_id_organization_id_fk": {
+          "name": "bug_report_upload_session_organization_id_organization_id_fk",
+          "tableFrom": "bug_report_upload_session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bug_report_upload_session_reporter_id_user_id_fk": {
+          "name": "bug_report_upload_session_reporter_id_user_id_fk",
+          "tableFrom": "bug_report_upload_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_public_key": {
+      "name": "capture_public_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capture_public_key_organizationId_idx": {
+          "name": "capture_public_key_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_public_key_status_idx": {
+          "name": "capture_public_key_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_public_key_organization_id_organization_id_fk": {
+          "name": "capture_public_key_organization_id_organization_id_fk",
+          "tableFrom": "capture_public_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capture_public_key_created_by_user_id_fk": {
+          "name": "capture_public_key_created_by_user_id_fk",
+          "tableFrom": "capture_public_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capture_public_key_key_unique": {
+          "name": "capture_public_key_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_webhook_event": {
+      "name": "billing_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polar'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_event_type_idx": {
+          "name": "billing_webhook_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_status_idx": {
+          "name": "billing_webhook_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_webhook_event_provider_event_id_unique": {
+          "name": "billing_webhook_event_provider_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_billing_account": {
+      "name": "organization_billing_account",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polar'"
+        },
+        "polar_customer_id": {
+          "name": "polar_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polar_subscription_id": {
+          "name": "polar_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_webhook_at": {
+          "name": "last_webhook_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_billing_plan_idx": {
+          "name": "org_billing_plan_idx",
+          "columns": [
+            {
+              "expression": "plan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_billing_polar_customer_idx": {
+          "name": "org_billing_polar_customer_idx",
+          "columns": [
+            {
+              "expression": "polar_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_billing_account_organization_id_organization_id_fk": {
+          "name": "organization_billing_account_organization_id_organization_id_fk",
+          "tableFrom": "organization_billing_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_billing_account_polar_subscription_id_unique": {
+          "name": "organization_billing_account_polar_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polar_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_entitlement": {
+      "name": "organization_entitlement",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "entitlements": {
+          "name": "entitlements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_computed_at": {
+          "name": "last_computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reconciliation'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_plan_idx": {
+          "name": "org_entitlement_plan_idx",
+          "columns": [
+            {
+              "expression": "plan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_entitlement_organization_id_organization_id_fk": {
+          "name": "organization_entitlement_organization_id_organization_id_fk",
+          "tableFrom": "organization_entitlement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_key_unique": {
+          "name": "rate_limit_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/0002_snapshot.json
+++ b/packages/db/src/migrations/meta/0002_snapshot.json
@@ -1,0 +1,2358 @@
+{
+  "id": "6584a736-9c49-48ed-8387-21f808fdd939",
+  "prevId": "c8bea055-b892-47d9-b753-841d7446260b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_key_unique": {
+          "name": "rate_limit_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_webhook_event": {
+      "name": "billing_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polar'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_webhook_event_type_idx": {
+          "name": "billing_webhook_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_webhook_status_idx": {
+          "name": "billing_webhook_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_webhook_event_provider_event_id_unique": {
+          "name": "billing_webhook_event_provider_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_billing_account": {
+      "name": "organization_billing_account",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polar'"
+        },
+        "polar_customer_id": {
+          "name": "polar_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polar_subscription_id": {
+          "name": "polar_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_webhook_at": {
+          "name": "last_webhook_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_billing_plan_idx": {
+          "name": "org_billing_plan_idx",
+          "columns": [
+            {
+              "expression": "plan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_billing_polar_customer_idx": {
+          "name": "org_billing_polar_customer_idx",
+          "columns": [
+            {
+              "expression": "polar_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_billing_account_organization_id_organization_id_fk": {
+          "name": "organization_billing_account_organization_id_organization_id_fk",
+          "tableFrom": "organization_billing_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_billing_account_polar_subscription_id_unique": {
+          "name": "organization_billing_account_polar_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polar_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_entitlement": {
+      "name": "organization_entitlement",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "entitlements": {
+          "name": "entitlements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_computed_at": {
+          "name": "last_computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reconciliation'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_entitlement_plan_idx": {
+          "name": "org_entitlement_plan_idx",
+          "columns": [
+            {
+              "expression": "plan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_entitlement_organization_id_organization_id_fk": {
+          "name": "organization_entitlement_organization_id_organization_id_fk",
+          "tableFrom": "organization_entitlement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report": {
+      "name": "bug_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_key": {
+          "name": "capture_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_content_type": {
+          "name": "capture_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_size_bytes": {
+          "name": "capture_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_uploaded_at": {
+          "name": "capture_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_content_type": {
+          "name": "thumbnail_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_key": {
+          "name": "debugger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_content_encoding": {
+          "name": "debugger_content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_size_bytes": {
+          "name": "debugger_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_uploaded_at": {
+          "name": "debugger_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_ingestion_status": {
+          "name": "debugger_ingestion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "debugger_ingestion_error": {
+          "name": "debugger_ingestion_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugger_ingested_at": {
+          "name": "debugger_ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_organizationId_idx": {
+          "name": "bug_report_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_reporterId_idx": {
+          "name": "bug_report_reporterId_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_submissionStatus_idx": {
+          "name": "bug_report_submissionStatus_idx",
+          "columns": [
+            {
+              "expression": "submission_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_debuggerIngestionStatus_idx": {
+          "name": "bug_report_debuggerIngestionStatus_idx",
+          "columns": [
+            {
+              "expression": "debugger_ingestion_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_organization_id_organization_id_fk": {
+          "name": "bug_report_organization_id_organization_id_fk",
+          "tableFrom": "bug_report",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bug_report_reporter_id_user_id_fk": {
+          "name": "bug_report_reporter_id_user_id_fk",
+          "tableFrom": "bug_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_action": {
+      "name": "bug_report_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bug_report_action_bugReportId_idx": {
+          "name": "bug_report_action_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_action_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_action_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_action",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_artifact_cleanup": {
+      "name": "bug_report_artifact_cleanup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artifact_kind": {
+          "name": "artifact_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_artifact_cleanup_nextAttemptAt_idx": {
+          "name": "bug_report_artifact_cleanup_nextAttemptAt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bug_report_artifact_cleanup_object_key_unique": {
+          "name": "bug_report_artifact_cleanup_object_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_ingestion_job": {
+      "name": "bug_report_ingestion_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_ingestion_job_bugReportId_idx": {
+          "name": "bug_report_ingestion_job_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_ingestion_job_status_idx": {
+          "name": "bug_report_ingestion_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_ingestion_job_nextAttemptAt_idx": {
+          "name": "bug_report_ingestion_job_nextAttemptAt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_ingestion_job_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_ingestion_job_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_ingestion_job",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bug_report_ingestion_job_organization_id_organization_id_fk": {
+          "name": "bug_report_ingestion_job_organization_id_organization_id_fk",
+          "tableFrom": "bug_report_ingestion_job",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_log": {
+      "name": "bug_report_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bug_report_log_bugReportId_idx": {
+          "name": "bug_report_log_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_log_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_log_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_log",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_network_request": {
+      "name": "bug_report_network_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bug_report_id": {
+          "name": "bug_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bug_report_network_request_bugReportId_idx": {
+          "name": "bug_report_network_request_bugReportId_idx",
+          "columns": [
+            {
+              "expression": "bug_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_network_request_bug_report_id_bug_report_id_fk": {
+          "name": "bug_report_network_request_bug_report_id_bug_report_id_fk",
+          "tableFrom": "bug_report_network_request",
+          "tableTo": "bug_report",
+          "columnsFrom": [
+            "bug_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bug_report_upload_session": {
+      "name": "bug_report_upload_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "capture_key": {
+          "name": "capture_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_content_type": {
+          "name": "capture_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debugger_key": {
+          "name": "debugger_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bug_report_upload_session_organizationId_idx": {
+          "name": "bug_report_upload_session_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bug_report_upload_session_expiresAt_idx": {
+          "name": "bug_report_upload_session_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bug_report_upload_session_organization_id_organization_id_fk": {
+          "name": "bug_report_upload_session_organization_id_organization_id_fk",
+          "tableFrom": "bug_report_upload_session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bug_report_upload_session_reporter_id_user_id_fk": {
+          "name": "bug_report_upload_session_reporter_id_user_id_fk",
+          "tableFrom": "bug_report_upload_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_public_key": {
+      "name": "capture_public_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capture_public_key_organizationId_idx": {
+          "name": "capture_public_key_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_public_key_status_idx": {
+          "name": "capture_public_key_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_public_key_organization_id_organization_id_fk": {
+          "name": "capture_public_key_organization_id_organization_id_fk",
+          "tableFrom": "capture_public_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "capture_public_key_created_by_user_id_fk": {
+          "name": "capture_public_key_created_by_user_id_fk",
+          "tableFrom": "capture_public_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capture_public_key_key_unique": {
+          "name": "capture_public_key_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_github_integration": {
+      "name": "organization_github_integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_github_integration_organizationId_idx": {
+          "name": "org_github_integration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_github_integration_organizationId_unique": {
+          "name": "org_github_integration_organizationId_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_github_integration_organization_id_organization_id_fk": {
+          "name": "organization_github_integration_organization_id_organization_id_fk",
+          "tableFrom": "organization_github_integration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776875942269,
       "tag": "0001_military_black_tom",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776975284247,
+      "tag": "0002_add_bug_report_github_issue_url",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772496592578,
       "tag": "0000_tidy_thundra",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776875942269,
+      "tag": "0001_military_black_tom",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/bug-report.ts
+++ b/packages/db/src/schema/bug-report.ts
@@ -44,6 +44,10 @@ export const bugReport = pgTable(
     debuggerIngestedAt: timestamp("debugger_ingested_at"),
     submissionStatus: text("submission_status").default("ready").notNull(),
     visibility: text("visibility").default("private").notNull(), // public | private
+    // Populated by the GitHub integration when an issue is created for this
+    // report. Null if (a) the org has no GitHub integration configured, or
+    // (b) the integration call failed — both are non-fatal for capture.
+    githubIssueUrl: text("github_issue_url"),
     metadata: jsonb("metadata"),
     deviceInfo: jsonb("device_info"), // browser, os, viewport, etc.
     createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/packages/db/src/schema/github-integration.ts
+++ b/packages/db/src/schema/github-integration.ts
@@ -1,0 +1,36 @@
+import { relations } from "drizzle-orm"
+import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
+import { organization } from "./auth"
+
+export const organizationGithubIntegration = pgTable(
+  "organization_github_integration",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    repo: text("repo").notNull(),
+    tokenEncrypted: text("token_encrypted").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("org_github_integration_organizationId_idx").on(table.organizationId),
+    uniqueIndex("org_github_integration_organizationId_unique").on(
+      table.organizationId
+    ),
+  ]
+)
+
+export const organizationGithubIntegrationRelations = relations(
+  organizationGithubIntegration,
+  ({ one }) => ({
+    organization: one(organization, {
+      fields: [organizationGithubIntegration.organizationId],
+      references: [organization.id],
+    }),
+  })
+)

--- a/packages/db/src/schema/github-integration.ts
+++ b/packages/db/src/schema/github-integration.ts
@@ -1,5 +1,11 @@
 import { relations } from "drizzle-orm"
-import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core"
 import { organization } from "./auth"
 
 export const organizationGithubIntegration = pgTable(

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth"
 export * from "./billing"
 export * from "./bug-report"
+export * from "./github-integration"

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -56,8 +56,6 @@ export const env = createEnv({
     CAPTURE_SUBMIT_TOKEN_SECRET: z.string().min(32).optional(),
     TURNSTILE_SITE_KEY: z.string().min(1).optional(),
     TURNSTILE_SECRET_KEY: z.string().min(1).optional(),
-    GITHUB_ISSUES_REPO: z.string().min(1).optional(),
-    GITHUB_ISSUES_TOKEN: z.string().min(1).optional(),
     NODE_ENV: z
       .enum(["development", "production", "staging"])
       .default("development"),

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -46,6 +46,7 @@ export const env = createEnv({
     STORAGE_BUCKET: z.string().min(1).optional(),
     STORAGE_REGION: z.string().min(1).optional(),
     STORAGE_ENDPOINT: z.url().optional(),
+    STORAGE_PUBLIC_ENDPOINT: z.url().optional(),
     STORAGE_ADDRESSING_STYLE: z.enum(["auto", "path", "virtual"]).optional(),
     STORAGE_ACCESS_KEY_ID: z.string().min(1).optional(),
     STORAGE_SECRET_ACCESS_KEY: z.string().min(1).optional(),
@@ -55,6 +56,8 @@ export const env = createEnv({
     CAPTURE_SUBMIT_TOKEN_SECRET: z.string().min(32).optional(),
     TURNSTILE_SITE_KEY: z.string().min(1).optional(),
     TURNSTILE_SECRET_KEY: z.string().min(1).optional(),
+    GITHUB_ISSUES_REPO: z.string().min(1).optional(),
+    GITHUB_ISSUES_TOKEN: z.string().min(1).optional(),
     NODE_ENV: z
       .enum(["development", "production", "staging"])
       .default("development"),

--- a/packages/shared/src/lib/server/crypto.ts
+++ b/packages/shared/src/lib/server/crypto.ts
@@ -1,4 +1,9 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto"
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from "node:crypto"
 
 const ALGORITHM = "aes-256-gcm"
 const IV_LENGTH = 12
@@ -17,7 +22,10 @@ export function encryptSecret(plaintext: string, secret: string): string {
   const key = deriveKey(secret)
   const iv = randomBytes(IV_LENGTH)
   const cipher = createCipheriv(ALGORITHM, key, iv)
-  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()])
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ])
   const authTag = cipher.getAuthTag()
   return Buffer.concat([iv, encrypted, authTag]).toString("base64")
 }
@@ -33,6 +41,9 @@ export function decryptSecret(blob: string, secret: string): string {
   const ciphertext = buf.subarray(IV_LENGTH, buf.length - AUTH_TAG_LENGTH)
   const decipher = createDecipheriv(ALGORITHM, key, iv)
   decipher.setAuthTag(authTag)
-  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ])
   return decrypted.toString("utf8")
 }

--- a/packages/shared/src/lib/server/crypto.ts
+++ b/packages/shared/src/lib/server/crypto.ts
@@ -1,0 +1,38 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto"
+
+const ALGORITHM = "aes-256-gcm"
+const IV_LENGTH = 12
+const AUTH_TAG_LENGTH = 16
+
+function deriveKey(secret: string): Buffer {
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      "Crypto secret must be at least 32 characters. Check BETTER_AUTH_SECRET."
+    )
+  }
+  return createHash("sha256").update(secret).digest()
+}
+
+export function encryptSecret(plaintext: string, secret: string): string {
+  const key = deriveKey(secret)
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()])
+  const authTag = cipher.getAuthTag()
+  return Buffer.concat([iv, encrypted, authTag]).toString("base64")
+}
+
+export function decryptSecret(blob: string, secret: string): string {
+  const key = deriveKey(secret)
+  const buf = Buffer.from(blob, "base64")
+  if (buf.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+    throw new Error("Invalid encrypted blob: too short")
+  }
+  const iv = buf.subarray(0, IV_LENGTH)
+  const authTag = buf.subarray(buf.length - AUTH_TAG_LENGTH)
+  const ciphertext = buf.subarray(IV_LENGTH, buf.length - AUTH_TAG_LENGTH)
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(authTag)
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  return decrypted.toString("utf8")
+}

--- a/sdks/capture/src/runtime/capture-runtime.ts
+++ b/sdks/capture/src/runtime/capture-runtime.ts
@@ -232,7 +232,10 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
     })
 
     if (this.mountedUi) {
-      this.mountedUi.store.showSuccess(result.shareUrl)
+      this.mountedUi.store.showSuccess({
+        shareUrl: result.shareUrl,
+        githubIssueUrl: result.githubIssueUrl,
+      })
     }
 
     return result

--- a/sdks/capture/src/transport/default-submit-transport.ts
+++ b/sdks/capture/src/transport/default-submit-transport.ts
@@ -99,6 +99,9 @@ export async function defaultSubmitTransport(
       resolveString(responsePayload, ["shareUrl", "url"])
     ),
     reportId: resolveString(responsePayload, ["id", "reportId"]),
+    // GitHub URL is server-absolute (api.github.com is the source) — no host
+    // prepending. May be missing entirely when the org has no integration.
+    githubIssueUrl: resolveString(responsePayload, ["githubIssueUrl"]),
     raw: responsePayload,
   }
 }

--- a/sdks/capture/src/types.ts
+++ b/sdks/capture/src/types.ts
@@ -130,6 +130,10 @@ export interface CaptureSubmitRequest {
 export interface CaptureSubmitResult {
   shareUrl?: string
   reportId?: string
+  // Set when the host server forwarded the report to a configured GitHub
+  // integration and the issue was created successfully. Surfaces in the SDK
+  // success modal.
+  githubIssueUrl?: string
   raw?: unknown
 }
 

--- a/sdks/capture/src/ui/capture-widget/sections/success-section.tsx
+++ b/sdks/capture/src/ui/capture-widget/sections/success-section.tsx
@@ -46,6 +46,21 @@ export function SuccessSection(props: {
         </div>
       </div>
 
+      {props.state.githubIssueUrl ? (
+        <div className="grid gap-2">
+          <Label>GitHub Issue</Label>
+          <a
+            className="inline-flex items-center gap-1.5 text-sm underline underline-offset-2 hover:no-underline"
+            href={props.state.githubIssueUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ExternalLinkIcon className="h-3.5 w-3.5" />
+            {props.state.githubIssueUrl}
+          </a>
+        </div>
+      ) : null}
+
       <div className="grid gap-2 sm:grid-cols-2">
         <Button
           className="w-full gap-2"

--- a/sdks/capture/src/ui/store/capture-ui-store.ts
+++ b/sdks/capture/src/ui/store/capture-ui-store.ts
@@ -48,6 +48,7 @@ export function createCaptureUiStore(): CaptureUiStore {
       warnings: [...input.warnings],
       summary: input.summary,
       shareUrl: "",
+      githubIssueUrl: "",
       copyLabel: "Copy Link",
       reviewDraft: {
         title: "",
@@ -98,7 +99,7 @@ export function createCaptureUiStore(): CaptureUiStore {
       })
     },
     showReview,
-    showSuccess: (shareUrl) => {
+    showSuccess: (input) => {
       patchState({
         overlayOpen: true,
         recordingDockOpen: false,
@@ -106,7 +107,8 @@ export function createCaptureUiStore(): CaptureUiStore {
         view: "success",
         errorMessage: null,
         busy: false,
-        shareUrl: shareUrl ?? "",
+        shareUrl: input.shareUrl ?? "",
+        githubIssueUrl: input.githubIssueUrl ?? "",
         copyLabel: "Copy Link",
       })
     },
@@ -146,6 +148,7 @@ function createInitialState(): CaptureUiState {
     summary: { ...DEFAULT_SUMMARY },
     media: null,
     shareUrl: "",
+    githubIssueUrl: "",
     copyLabel: "Copy Link",
     reviewDraft: {
       title: "",

--- a/sdks/capture/src/ui/types.ts
+++ b/sdks/capture/src/ui/types.ts
@@ -19,6 +19,10 @@ export interface CaptureUiState {
   summary: CaptureDebuggerSummary
   media: CapturedMedia | null
   shareUrl: string
+  // GitHub issue URL surfaced by the host server when its GitHub integration
+  // is configured. Empty string when absent — keeps the field non-optional so
+  // selectors don't need null-guards.
+  githubIssueUrl: string
   copyLabel: string
   reviewDraft: CaptureSubmissionDraft
   reviewFormKey: string
@@ -64,7 +68,7 @@ export interface CaptureUiStore {
     warnings: string[]
     summary: CaptureDebuggerSummary
   }) => void
-  showSuccess: (shareUrl?: string) => void
+  showSuccess: (input: { shareUrl?: string; githubIssueUrl?: string }) => void
   showError: (message: string) => void
   setTitleIfEmpty: (value: string) => void
   destroy: () => void

--- a/sdks/capture/test/lib/sdk-test-harness.ts
+++ b/sdks/capture/test/lib/sdk-test-harness.ts
@@ -130,8 +130,11 @@ mock.module(MOUNT_CAPTURE_UI_PATH, () => ({
         showReview: (input: ReviewInput) => {
           sdkTestState.uiShowReviewInputs.push(input)
         },
-        showSuccess: (shareUrl?: string) => {
-          sdkTestState.uiShowSuccessUrls.push(shareUrl)
+        showSuccess: (input: {
+          shareUrl?: string
+          githubIssueUrl?: string
+        }) => {
+          sdkTestState.uiShowSuccessUrls.push(input.shareUrl)
         },
         showError: () => undefined,
         setTitleIfEmpty: (value: string) => {


### PR DESCRIPTION
Add an optional integration that forwards crikket bug reports to a GitHub repo as issues. Artifacts (capture + debugger payload) are uploaded to a dedicated `crikket-attachments` branch on the target repo and linked from the issue body.

- packages/db: `github_integration` table (per-user-or-tenant repo + AES-GCM encrypted token) with initial migration.
- packages/shared/server/crypto: AES-256-GCM encrypt/decrypt helper keyed off BETTER_AUTH_SECRET.
- packages/bug-reports: new `integrations.ts` forwarder, config loader, and procedures to create/update/test/delete the integration. Ensures the attachments branch exists and uploads via the GitHub Contents API.
- packages/api: `githubIntegration` tRPC router.
- packages/env: add GITHUB_ISSUES_REPO, GITHUB_ISSUES_TOKEN, STORAGE_PUBLIC_ENDPOINT env vars.
- apps/web: settings page (Integrations → GitHub) with a form to configure repo + token and test connectivity.

Attachment links use github.com/<repo>/blob/<branch>/<path> rather than raw.githubusercontent.com so they resolve for authorized viewers of private repos (raw.github... 404s without a bearer token). No inline image embed — GitHub's Camo proxy can't fetch private content so the embed would always show a broken image icon.