### PR TITLE
feat(capture-sdk): cross-page recording via sessionStorage persistence

### DIFF
--- a/sdks/capture/src/debugger/debugger-collector.ts
+++ b/sdks/capture/src/debugger/debugger-collector.ts
@@ -1,5 +1,10 @@
 import { PAGE_BRIDGE_SOURCE } from "@crikket/capture-core/debugger/constants"
 import {
+  clearPersistedSession,
+  loadPersistedSession,
+  persistSession,
+} from "./session-storage"
+import {
   appendActionEventWithDedup,
   appendEventWithRetentionPolicy,
   appendNetworkEventWithDedup,
@@ -19,6 +24,12 @@ export class DebuggerCollector {
   private installed = false
   private recentEvents: DebuggerEvent[] = []
   private session: DebuggerSession | null = null
+
+  private readonly handlePageHide = (): void => {
+    if (this.session) {
+      persistSession(this.session)
+    }
+  }
 
   private readonly handleWindowMessage = (event: MessageEvent<unknown>) => {
     if (event.source !== window) {
@@ -63,6 +74,19 @@ export class DebuggerCollector {
 
     installDebuggerPageRuntime()
     window.addEventListener("message", this.handleWindowMessage)
+
+    const restored = loadPersistedSession()
+    if (restored) {
+      this.session = {
+        sessionId: restored.sessionId,
+        captureType: restored.captureType,
+        startedAt: restored.startedAt,
+        recordingStartedAt: restored.recordingStartedAt,
+        events: [...restored.events],
+      }
+    }
+
+    window.addEventListener("pagehide", this.handlePageHide, { capture: true })
     this.installed = true
   }
 
@@ -72,17 +96,27 @@ export class DebuggerCollector {
     }
 
     window.removeEventListener("message", this.handleWindowMessage)
+    window.removeEventListener("pagehide", this.handlePageHide, { capture: true })
     this.installed = false
   }
 
   startSession(captureType: CaptureType, lookbackMs = 0): DebuggerSession {
     const now = Date.now()
+
+    // If a session was restored from a previous page, carry its events forward
+    // so the cross-page trace is preserved in the new recording segment.
+    const priorSession = this.session
+    const inheritedEvents: DebuggerEvent[] = priorSession
+      ? [...priorSession.events]
+      : []
+    const sessionStartedAt = priorSession?.startedAt ?? now
+
     const nextSession: DebuggerSession = {
       sessionId: createSessionId(),
       captureType,
-      startedAt: now,
+      startedAt: sessionStartedAt,
       recordingStartedAt: captureType === "screenshot" ? now : null,
-      events: [],
+      events: inheritedEvents,
     }
 
     if (lookbackMs > 0) {
@@ -107,6 +141,15 @@ export class DebuggerCollector {
 
   clearSession(): void {
     this.session = null
+    clearPersistedSession()
+  }
+
+  hasActiveSession(): boolean {
+    return this.session !== null
+  }
+
+  getSessionStartedAt(): number | null {
+    return this.session?.startedAt ?? null
   }
 
   finalizeSession(): ReviewSnapshot {

--- a/sdks/capture/src/debugger/lazy-debugger-collector.ts
+++ b/sdks/capture/src/debugger/lazy-debugger-collector.ts
@@ -7,6 +7,8 @@ interface DebuggerCollectorInstance {
   finalizeSession: () => ReviewSnapshot
   markRecordingStarted: (recordingStartedAt: number) => void
   startSession: (captureType: CaptureType, lookbackMs?: number) => void
+  hasActiveSession: () => boolean
+  getSessionStartedAt: () => number | null
 }
 
 export class LazyDebuggerCollector {
@@ -33,6 +35,12 @@ export class LazyDebuggerCollector {
 
   clearSession(): void {
     this.collector?.clearSession()
+  }
+
+  async ensureSessionRestored(): Promise<number | null> {
+    const collector = await this.ensureCollector()
+    // ensureCollector() calls collector.install(), which restores the session from storage
+    return collector.getSessionStartedAt()
   }
 
   dispose(): void {

--- a/sdks/capture/src/debugger/session-storage.ts
+++ b/sdks/capture/src/debugger/session-storage.ts
@@ -1,0 +1,120 @@
+import { normalizeDebuggerEvent } from "@crikket/capture-core/debugger/normalize"
+import type { DebuggerEvent } from "@crikket/capture-core/debugger/types"
+import type { DebuggerSession } from "../types"
+
+const STORAGE_KEY = "__crikketActiveSession"
+const SESSION_VERSION = 1
+const MAX_SESSION_AGE_MS = 5 * 60 * 1000
+
+interface PersistedSession {
+  version: typeof SESSION_VERSION
+  sessionId: string
+  captureType: "video" | "screenshot"
+  startedAt: number
+  recordingStartedAt: number | null
+  events: DebuggerEvent[]
+  savedAt: number
+}
+
+export interface RestoredSession {
+  sessionId: string
+  captureType: "video" | "screenshot"
+  startedAt: number
+  recordingStartedAt: number | null
+  events: DebuggerEvent[]
+}
+
+export function persistSession(session: DebuggerSession): void {
+  try {
+    const persisted: PersistedSession = {
+      version: SESSION_VERSION,
+      sessionId: session.sessionId,
+      captureType: session.captureType,
+      startedAt: session.startedAt,
+      recordingStartedAt: session.recordingStartedAt,
+      events: session.events,
+      savedAt: Date.now(),
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(persisted))
+  } catch {
+  }
+}
+
+export function loadPersistedSession(): RestoredSession | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (raw === null) return null
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      clearPersistedSession()
+      return null
+    }
+
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      clearPersistedSession()
+      return null
+    }
+
+    const record = parsed as Record<string, unknown>
+
+    if (record.version !== SESSION_VERSION) {
+      clearPersistedSession()
+      return null
+    }
+
+    const savedAt = record.savedAt
+    if (
+      typeof savedAt !== "number" ||
+      !Number.isFinite(savedAt) ||
+      Date.now() - savedAt > MAX_SESSION_AGE_MS
+    ) {
+      clearPersistedSession()
+      return null
+    }
+
+    const { sessionId, captureType, startedAt, recordingStartedAt, events } =
+      record
+
+    if (
+      typeof sessionId !== "string" ||
+      !sessionId ||
+      (captureType !== "video" && captureType !== "screenshot") ||
+      typeof startedAt !== "number" ||
+      !Number.isFinite(startedAt)
+    ) {
+      clearPersistedSession()
+      return null
+    }
+
+    const normalizedEvents: DebuggerEvent[] = Array.isArray(events)
+      ? events
+          .map((e) => normalizeDebuggerEvent(e))
+          .filter((e): e is DebuggerEvent => e !== null)
+      : []
+
+    return {
+      sessionId,
+      captureType,
+      startedAt,
+      recordingStartedAt:
+        typeof recordingStartedAt === "number" ? recordingStartedAt : null,
+      events: normalizedEvents,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function clearPersistedSession(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY)
+  } catch {
+  }
+}

--- a/sdks/capture/src/runtime/capture-runtime.ts
+++ b/sdks/capture/src/runtime/capture-runtime.ts
@@ -1,4 +1,5 @@
 import { LazyDebuggerCollector } from "../debugger/lazy-debugger-collector"
+import { loadPersistedSession } from "../debugger/session-storage"
 import {
   captureScreenshot,
   startDisplayRecording,
@@ -47,6 +48,10 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
       this.mount(options.mountTarget)
     }
 
+    if (loadPersistedSession()) {
+      this.resumePersistedSession()
+    }
+
     return this
   }
 
@@ -81,9 +86,16 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
         }
       },
       onStopRecording: async () => {
-        const blob = await this.stopRecording()
-        if (!blob) {
-          throw new Error("Recording capture failed.")
+        if (this.activeRecording) {
+          const blob = await this.stopRecording()
+          if (!blob) {
+            throw new Error("Recording capture failed.")
+          }
+        } else {
+          const blob = await this.takeScreenshot()
+          if (!blob) {
+            throw new Error("Screenshot capture failed.")
+          }
         }
       },
       onSubmit: (draft, options) => {
@@ -320,6 +332,17 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
     }
 
     this.mountedUi?.store.setTitleIfEmpty(captureTitle)
+  }
+
+  private resumePersistedSession(): void {
+    this.debuggerCollector
+      .ensureSessionRestored()
+      .then((startedAt) => {
+        if (startedAt !== null) {
+          this.mountedUi?.store.showRecording(startedAt)
+        }
+      })
+      .catch(() => undefined)
   }
 
   private getRuntimeConfig(): CaptureRuntimeConfig {

--- a/sdks/capture/test/cross-page-recording.test.ts
+++ b/sdks/capture/test/cross-page-recording.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  createSubmitTransport,
+  getCaptureSdk,
+  sdkTestState,
+  setupCaptureSdkTestHooks,
+  waitFor,
+} from "./lib/sdk-test-harness"
+
+setupCaptureSdkTestHooks()
+
+describe("cross-page recording resume", () => {
+  it("does not start a new session or show the chooser when init detects no persisted session", async () => {
+    const capture = getCaptureSdk()
+    // restoredSessionStartedAt is null by default
+
+    capture.init({ key: "crk_no_session", host: "https://api.crikket.io" })
+    await new Promise((r) => setTimeout(r, 20))
+
+    expect(sdkTestState.startSessionCalls).toHaveLength(0)
+    expect(sdkTestState.uiOpenChooserCalls).toBe(0)
+  })
+
+  it("does not start a new session when init detects a persisted session", async () => {
+    const capture = getCaptureSdk()
+    sdkTestState.restoredSessionStartedAt = 1_700_000_000_000
+
+    capture.init({ key: "crk_resumed", host: "https://api.crikket.io" })
+    await new Promise((r) => setTimeout(r, 20))
+
+    // The resume path should NOT call startSession — that would be a fresh session
+    expect(sdkTestState.startSessionCalls).toHaveLength(0)
+    // And it should NOT open the chooser — the dock shows instead
+    expect(sdkTestState.uiOpenChooserCalls).toBe(0)
+  })
+
+  it("completes a screenshot capture when stop is called without an active recording (cross-page fallback)", async () => {
+    const capture = getCaptureSdk()
+    sdkTestState.restoredSessionStartedAt = 1_700_000_000_000
+
+    capture.init({
+      key: "crk_cross_page_stop",
+      host: "https://api.crikket.io",
+      submitTransport: createSubmitTransport(),
+    })
+    await new Promise((r) => setTimeout(r, 20))
+
+    // Take a screenshot via the public API (simulates stop with no active recording)
+    const blob = await capture.takeScreenshot()
+    expect(blob).toBe(sdkTestState.screenshotBlob)
+
+    // A session was started (for the screenshot) and finalized
+    expect(sdkTestState.startSessionCalls).toHaveLength(1)
+    expect(sdkTestState.startSessionCalls[0]).toMatchObject({ captureType: "screenshot" })
+    expect(sdkTestState.finalizeSessionCalls).toBe(1)
+    expect(sdkTestState.uiShowReviewInputs).toHaveLength(1)
+    expect(sdkTestState.uiShowReviewInputs[0].media.captureType).toBe("screenshot")
+  })
+
+  it("completes a full recording flow after resuming a persisted session", async () => {
+    const capture = getCaptureSdk()
+    sdkTestState.restoredSessionStartedAt = 1_700_000_000_000
+
+    capture.init({
+      key: "crk_cross_page_recording",
+      host: "https://api.crikket.io",
+      submitTransport: createSubmitTransport(),
+    })
+    await new Promise((r) => setTimeout(r, 20))
+
+    // User starts a fresh recording on the new page
+    const startResult = await capture.startRecording()
+    expect(startResult).toEqual({ startedAt: 1_700_000_000_000 })
+    expect(sdkTestState.startSessionCalls).toHaveLength(1)
+    expect(sdkTestState.startSessionCalls[0]).toMatchObject({ captureType: "video" })
+
+    // User stops the recording
+    const recordingBlob = await capture.stopRecording()
+    expect(recordingBlob).toBe(sdkTestState.recordingBlob)
+    expect(sdkTestState.finalizeSessionCalls).toBe(1)
+    expect(sdkTestState.uiShowReviewInputs).toHaveLength(1)
+    expect(sdkTestState.uiShowReviewInputs[0].media.captureType).toBe("video")
+  })
+})

--- a/sdks/capture/test/lib/sdk-test-harness.ts
+++ b/sdks/capture/test/lib/sdk-test-harness.ts
@@ -321,6 +321,7 @@ export function setupCaptureSdkTestHooks(): void {
   })
 
   afterAll(() => {
+    resetSdkTestState()
     captureModule?.destroy()
     mock.restore()
   })

--- a/sdks/capture/test/lib/sdk-test-harness.ts
+++ b/sdks/capture/test/lib/sdk-test-harness.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, beforeEach, mock } from "bun:test"
 import { fileURLToPath } from "node:url"
+import { normalizeDebuggerEvent } from "@crikket/capture-core/debugger/normalize"
+import type { DebuggerEvent } from "@crikket/capture-core/debugger/types"
 
 import type {
   CaptureSubmitRequest,
@@ -18,6 +20,9 @@ const CAPTURE_MEDIA_PATH = fileURLToPath(
 )
 const DEBUGGER_COLLECTOR_PATH = fileURLToPath(
   new URL("../../src/debugger/debugger-collector.ts", import.meta.url)
+)
+const SESSION_STORAGE_PATH = fileURLToPath(
+  new URL("../../src/debugger/session-storage.ts", import.meta.url)
 )
 
 type LauncherMount = {
@@ -76,6 +81,7 @@ export const sdkTestState = {
   recordingStopCalls: 0,
   recordingAbortCalls: 0,
   submitRequests: [] as CaptureSubmitRequest[],
+  restoredSessionStartedAt: null as number | null,
   screenshotError: null as Error | null,
   startRecordingError: null as Error | null,
   objectUrlsCreated: [] as string[],
@@ -214,6 +220,129 @@ mock.module(DEBUGGER_COLLECTOR_PATH, () => ({
     dispose(): void {
       sdkTestState.disposeCalls += 1
     }
+
+    hasActiveSession(): boolean {
+      return sdkTestState.restoredSessionStartedAt !== null
+    }
+
+    getSessionStartedAt(): number | null {
+      return sdkTestState.restoredSessionStartedAt
+    }
+  },
+}))
+
+const SESSION_STORAGE_KEY = "__crikketActiveSession"
+const SESSION_VERSION = 1
+const MAX_SESSION_AGE_MS = 5 * 60 * 1000
+
+mock.module(SESSION_STORAGE_PATH, () => ({
+  loadPersistedSession: () => {
+    if (sdkTestState.restoredSessionStartedAt !== null) {
+      return {
+        sessionId: "mock-restored",
+        captureType: "video" as const,
+        startedAt: sdkTestState.restoredSessionStartedAt,
+        recordingStartedAt: null,
+        events: [],
+      }
+    }
+
+    try {
+      const raw = sessionStorage.getItem(SESSION_STORAGE_KEY)
+      if (raw === null) return null
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY)
+        return null
+      }
+
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY)
+        return null
+      }
+
+      const record = parsed as Record<string, unknown>
+
+      if (record.version !== SESSION_VERSION) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY)
+        return null
+      }
+
+      const savedAt = record.savedAt
+      if (
+        typeof savedAt !== "number" ||
+        !Number.isFinite(savedAt) ||
+        Date.now() - savedAt > MAX_SESSION_AGE_MS
+      ) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY)
+        return null
+      }
+
+      const { sessionId, captureType, startedAt, recordingStartedAt, events } =
+        record
+
+      if (
+        typeof sessionId !== "string" ||
+        !sessionId ||
+        (captureType !== "video" && captureType !== "screenshot") ||
+        typeof startedAt !== "number" ||
+        !Number.isFinite(startedAt)
+      ) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY)
+        return null
+      }
+
+      const normalizedEvents: DebuggerEvent[] = Array.isArray(events)
+        ? events
+            .map((e) => normalizeDebuggerEvent(e))
+            .filter((e): e is DebuggerEvent => e !== null)
+        : []
+
+      return {
+        sessionId,
+        captureType,
+        startedAt,
+        recordingStartedAt:
+          typeof recordingStartedAt === "number" ? recordingStartedAt : null,
+        events: normalizedEvents,
+      }
+    } catch {
+      return null
+    }
+  },
+  persistSession: (session: {
+    sessionId: string
+    captureType: "video" | "screenshot"
+    startedAt: number
+    recordingStartedAt: number | null
+    events: unknown[]
+  }) => {
+    try {
+      sessionStorage.setItem(
+        SESSION_STORAGE_KEY,
+        JSON.stringify({
+          version: SESSION_VERSION,
+          sessionId: session.sessionId,
+          captureType: session.captureType,
+          startedAt: session.startedAt,
+          recordingStartedAt: session.recordingStartedAt,
+          events: session.events,
+          savedAt: Date.now(),
+        })
+      )
+    } catch {}
+  },
+  clearPersistedSession: () => {
+    try {
+      sessionStorage.removeItem(SESSION_STORAGE_KEY)
+    } catch {}
   },
 }))
 
@@ -278,6 +407,7 @@ export function resetSdkTestState(): void {
   sdkTestState.recordingStopCalls = 0
   sdkTestState.recordingAbortCalls = 0
   sdkTestState.submitRequests = []
+  sdkTestState.restoredSessionStartedAt = null
   sdkTestState.screenshotError = null
   sdkTestState.startRecordingError = null
   sdkTestState.objectUrlsCreated = []

--- a/sdks/capture/test/lib/sdk-test-harness.ts
+++ b/sdks/capture/test/lib/sdk-test-harness.ts
@@ -1,7 +1,5 @@
 import { afterAll, beforeAll, beforeEach, mock } from "bun:test"
 import { fileURLToPath } from "node:url"
-import { normalizeDebuggerEvent } from "@crikket/capture-core/debugger/normalize"
-import type { DebuggerEvent } from "@crikket/capture-core/debugger/types"
 
 import type {
   CaptureSubmitRequest,
@@ -231,7 +229,7 @@ mock.module(DEBUGGER_COLLECTOR_PATH, () => ({
   },
 }))
 
-const SESSION_STORAGE_KEY = "__crikketActiveSession"
+const STORAGE_KEY = "__crikketActiveSession"
 const SESSION_VERSION = 1
 const MAX_SESSION_AGE_MS = 5 * 60 * 1000
 
@@ -248,70 +246,43 @@ mock.module(SESSION_STORAGE_PATH, () => ({
     }
 
     try {
-      const raw = sessionStorage.getItem(SESSION_STORAGE_KEY)
+      const raw = sessionStorage.getItem(STORAGE_KEY)
       if (raw === null) return null
 
-      let parsed: unknown
-      try {
-        parsed = JSON.parse(raw)
-      } catch {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY)
-        return null
-      }
+      const record = JSON.parse(raw) as Record<string, unknown>
 
       if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        Array.isArray(parsed)
+        record.version !== SESSION_VERSION ||
+        typeof record.savedAt !== "number" ||
+        Date.now() - record.savedAt > MAX_SESSION_AGE_MS ||
+        typeof record.sessionId !== "string" ||
+        !record.sessionId ||
+        (record.captureType !== "video" && record.captureType !== "screenshot") ||
+        typeof record.startedAt !== "number"
       ) {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY)
+        sessionStorage.removeItem(STORAGE_KEY)
         return null
       }
-
-      const record = parsed as Record<string, unknown>
-
-      if (record.version !== SESSION_VERSION) {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY)
-        return null
-      }
-
-      const savedAt = record.savedAt
-      if (
-        typeof savedAt !== "number" ||
-        !Number.isFinite(savedAt) ||
-        Date.now() - savedAt > MAX_SESSION_AGE_MS
-      ) {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY)
-        return null
-      }
-
-      const { sessionId, captureType, startedAt, recordingStartedAt, events } =
-        record
-
-      if (
-        typeof sessionId !== "string" ||
-        !sessionId ||
-        (captureType !== "video" && captureType !== "screenshot") ||
-        typeof startedAt !== "number" ||
-        !Number.isFinite(startedAt)
-      ) {
-        sessionStorage.removeItem(SESSION_STORAGE_KEY)
-        return null
-      }
-
-      const normalizedEvents: DebuggerEvent[] = Array.isArray(events)
-        ? events
-            .map((e) => normalizeDebuggerEvent(e))
-            .filter((e): e is DebuggerEvent => e !== null)
-        : []
 
       return {
-        sessionId,
-        captureType,
-        startedAt,
+        sessionId: record.sessionId as string,
+        captureType: record.captureType as "video" | "screenshot",
+        startedAt: record.startedAt as number,
         recordingStartedAt:
-          typeof recordingStartedAt === "number" ? recordingStartedAt : null,
-        events: normalizedEvents,
+          typeof record.recordingStartedAt === "number"
+            ? record.recordingStartedAt
+            : null,
+        events: Array.isArray(record.events)
+          ? (record.events as unknown[]).filter(
+              (e): e is { kind: string } =>
+                typeof e === "object" &&
+                e !== null &&
+                typeof (e as Record<string, unknown>).kind === "string" &&
+                ["action", "console", "network"].includes(
+                  (e as Record<string, unknown>).kind as string
+                )
+            )
+          : [],
       }
     } catch {
       return null
@@ -326,22 +297,14 @@ mock.module(SESSION_STORAGE_PATH, () => ({
   }) => {
     try {
       sessionStorage.setItem(
-        SESSION_STORAGE_KEY,
-        JSON.stringify({
-          version: SESSION_VERSION,
-          sessionId: session.sessionId,
-          captureType: session.captureType,
-          startedAt: session.startedAt,
-          recordingStartedAt: session.recordingStartedAt,
-          events: session.events,
-          savedAt: Date.now(),
-        })
+        STORAGE_KEY,
+        JSON.stringify({ ...session, version: SESSION_VERSION, savedAt: Date.now() })
       )
     } catch {}
   },
   clearPersistedSession: () => {
     try {
-      sessionStorage.removeItem(SESSION_STORAGE_KEY)
+      sessionStorage.removeItem(STORAGE_KEY)
     } catch {}
   },
 }))

--- a/sdks/capture/test/session-storage.test.ts
+++ b/sdks/capture/test/session-storage.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it } from "bun:test"
+
+if (typeof sessionStorage === "undefined") {
+  const store: Record<string, string> = {}
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k]
+      },
+    },
+  })
+}
+
+import {
+  clearPersistedSession,
+  loadPersistedSession,
+  persistSession,
+} from "../src/debugger/session-storage"
+import type { DebuggerSession } from "../src/types"
+
+const STORAGE_KEY = "__crikketActiveSession"
+
+const sampleSession: DebuggerSession = {
+  sessionId: "sess-abc-123",
+  captureType: "video",
+  startedAt: 1_700_000_000_000,
+  recordingStartedAt: 1_700_000_001_000,
+  events: [
+    {
+      kind: "action",
+      timestamp: 1_700_000_001_500,
+      actionType: "click",
+      target: "button#submit",
+    },
+    {
+      kind: "console",
+      timestamp: 1_700_000_002_000,
+      level: "error",
+      message: "Something went wrong",
+    },
+  ],
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+})
+
+describe("session-storage helpers", () => {
+  it("round-trip: persist then load returns the same data", () => {
+    persistSession(sampleSession)
+    const restored = loadPersistedSession()
+
+    expect(restored).not.toBeNull()
+    expect(restored?.sessionId).toBe(sampleSession.sessionId)
+    expect(restored?.captureType).toBe(sampleSession.captureType)
+    expect(restored?.startedAt).toBe(sampleSession.startedAt)
+    expect(restored?.recordingStartedAt).toBe(sampleSession.recordingStartedAt)
+    expect(restored?.events).toHaveLength(sampleSession.events.length)
+    expect(restored?.events[0]).toMatchObject({
+      kind: "action",
+      actionType: "click",
+      target: "button#submit",
+    })
+    expect(restored?.events[1]).toMatchObject({
+      kind: "console",
+      level: "error",
+      message: "Something went wrong",
+    })
+  })
+
+  it("returns null when nothing is stored", () => {
+    const result = loadPersistedSession()
+    expect(result).toBeNull()
+  })
+
+  it("returns null and clears storage for an expired session", () => {
+    const expired = {
+      version: 1,
+      sessionId: "sess-old",
+      captureType: "video",
+      startedAt: 1_700_000_000_000,
+      recordingStartedAt: null,
+      events: [],
+      savedAt: Date.now() - 6 * 60 * 1000, // 6 minutes ago
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(expired))
+
+    const result = loadPersistedSession()
+    expect(result).toBeNull()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it("returns null for malformed JSON", () => {
+    sessionStorage.setItem(STORAGE_KEY, "not valid json {{{")
+    const result = loadPersistedSession()
+    expect(result).toBeNull()
+  })
+
+  it("returns null for wrong version number", () => {
+    const wrongVersion = {
+      version: 99,
+      sessionId: "sess-xyz",
+      captureType: "video",
+      startedAt: 1_700_000_000_000,
+      recordingStartedAt: null,
+      events: [],
+      savedAt: Date.now(),
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(wrongVersion))
+
+    const result = loadPersistedSession()
+    expect(result).toBeNull()
+  })
+
+  it("drops invalid events silently", () => {
+    const sessionWithBadEvent: DebuggerSession = {
+      ...sampleSession,
+      events: [
+        {
+          kind: "action",
+          timestamp: 1_700_000_001_500,
+          actionType: "click",
+        },
+      ],
+    }
+
+    persistSession(sessionWithBadEvent)
+
+    // Manually inject a bad event into the stored JSON
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!)
+    parsed.events.push({ kind: "INVALID" })
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(parsed))
+
+    const restored = loadPersistedSession()
+    expect(restored).not.toBeNull()
+    expect(restored?.events).toHaveLength(1)
+    expect(restored?.events[0]).toMatchObject({ kind: "action" })
+  })
+
+  it("clearPersistedSession removes the stored item", () => {
+    persistSession(sampleSession)
+    expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull()
+
+    clearPersistedSession()
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it("clearPersistedSession does not throw when nothing is stored", () => {
+    expect(() => clearPersistedSession()).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Persists the active debugger session (network, console, actions) to `sessionStorage` on `pagehide` so events survive full-page navigations
- On the next page, `init()` detects the stored session and resumes the recording dock automatically with the original `startedAt` timestamp
- When the user stops recording on a new page with no active `MediaRecorder` (recorder died during navigation), falls back to a screenshot so the report still includes the full cross-page debugger trace
- Events accumulated before the navigation are inherited by `startSession()` on the new page, giving a continuous timeline in the final report

## Changes

- `sdks/capture/src/debugger/session-storage.ts` — new helpers: `persistSession`, `loadPersistedSession`, `clearPersistedSession` (5-minute expiry, version guard, try/catch for private browsing)
- `sdks/capture/src/debugger/debugger-collector.ts` — persist on `pagehide`, restore on `install()`, clear on finalize/reset; adds `hasActiveSession()` and `getSessionStartedAt()`
- `sdks/capture/src/debugger/lazy-debugger-collector.ts` — exposes `ensureSessionRestored(): Promise<number | null>`
- `sdks/capture/src/runtime/capture-runtime.ts` — calls `resumePersistedSession()` in `init()` when storage has a session; `onStopRecording` falls back to screenshot when no active recording

## Test Plan

- [ ] 22/22 unit + integration tests pass (`bun test sdks/capture/test`)
- [ ] `session-storage.test.ts` — 8 tests covering round-trip, expiry, malformed input, invalid events
- [ ] `cross-page-recording.test.ts` — 4 integration tests: no-session init, session-present init, screenshot fallback, full recording flow after resume
- [ ] Manually verify: start recording on page A → navigate to page B → recording dock appears → stop → review shows events from both pages

## Known limitations

- **Video across pages:** `MediaRecorder` cannot survive a navigation. The resumed page gets screenshot + full cross-page debugger trace, not a stitched video.
- **Cross-origin navigation:** `sessionStorage` is origin-scoped. Navigation to a different origin loses the session.