### PR TITLE
fix(capture): move bundled workspace deps to devDependencies

### DIFF
--- a/.changeset/fix-capture-workspace-deps.md
+++ b/.changeset/fix-capture-workspace-deps.md
@@ -1,0 +1,9 @@
+---
+"@crikket-io/capture": patch
+---
+
+Fix uninstallable package: move bundled `@crikket/*` workspace packages from
+`dependencies` to `devDependencies`. They are inlined into the dist bundle at
+build time (`--packages=bundle`, only react/react-dom external), so declaring
+them as runtime deps leaked unresolved `workspace:*` specifiers into the
+published tarball and broke `npm/pnpm/yarn install` in external projects.

--- a/sdks/capture/package.json
+++ b/sdks/capture/package.json
@@ -67,12 +67,10 @@
     "react": ">=18",
     "react-dom": ">=18"
   },
-  "dependencies": {
-    "@crikket/capture-core": "workspace:*",
-    "@crikket/shared": "workspace:*"
-  },
   "devDependencies": {
     "@tailwindcss/postcss": "catalog:",
+    "@crikket/capture-core": "workspace:*",
+    "@crikket/shared": "workspace:*",
     "@crikket/config": "workspace:*",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",


### PR DESCRIPTION
Fixes #80.

`@crikket-io/capture` ships with `@crikket/shared` and `@crikket/capture-core` as runtime `dependencies` using `workspace:*`. These never resolve outside the monorepo, so `npm`/`pnpm`/`yarn install` fail in external projects.

Both are already **bundled** into the dist output (`scripts/build.ts` uses `--packages=bundle` with only `react`/`react-dom` external), so they are build-time only. Moving them to `devDependencies` keeps the build working and stops the unresolved `workspace:*` specifiers from leaking into the published manifest.

Verified the dist bundle has no runtime import of either package (only a leftover `.d.ts` type reference).

Changeset included (patch).