### PR TITLE
fix(bug-reports): handle gzip debugger payload on S3 backends that decompress on read

### DIFF
--- a/.changeset/fix-debugger-double-decompression.md
+++ b/.changeset/fix-debugger-double-decompression.md
@@ -1,0 +1,10 @@
+---
+"@crikket/bug-reports": patch
+---
+
+Fix debugger ingestion failing with "incorrect header check" on S3 backends
+(Garage, MinIO) that transparently decompress `Content-Encoding: gzip` on read.
+Gate `gunzipSync` on the actual gzip magic bytes instead of the recorded
+encoding. Also stop 500ing the whole submission when the optional debugger
+payload fails — the report is already persisted, so return its
+`submissionStatus` instead.

--- a/apps/server/src/capture/finalize-route.ts
+++ b/apps/server/src/capture/finalize-route.ts
@@ -85,6 +85,7 @@ export async function handleCaptureFinalize(input: {
         id: result.id,
         reportId: result.id,
         shareUrl: new URL(result.shareUrl, input.shareOrigin).toString(),
+        submissionStatus: result.submissionStatus,
         warnings: result.warnings,
       },
       {

--- a/packages/bug-reports/src/lib/ingestion-jobs.ts
+++ b/packages/bug-reports/src/lib/ingestion-jobs.ts
@@ -362,10 +362,14 @@ async function ingestDebuggerPayload(input: {
 }): Promise<PersistBugReportDebuggerDataResult> {
   const storage = getStorageProvider()
   const storedPayload = await storage.read(input.debuggerKey)
-  const payloadBuffer =
-    input.debuggerContentEncoding === "gzip"
-      ? gunzipSync(storedPayload)
-      : storedPayload
+  // Some S3 backends decompress Content-Encoding: gzip on read, so check the
+  // actual magic bytes rather than the recorded encoding before gunzipping.
+  const isGzip =
+    input.debuggerContentEncoding === "gzip" &&
+    storedPayload.length >= 2 &&
+    storedPayload[0] === 0x1f &&
+    storedPayload[1] === 0x8b
+  const payloadBuffer = isGzip ? gunzipSync(storedPayload) : storedPayload
   const rawPayload = JSON.parse(payloadBuffer.toString("utf8")) as {
     actions?: unknown[]
     logs?: unknown[]

--- a/packages/bug-reports/src/lib/upload-session.ts
+++ b/packages/bug-reports/src/lib/upload-session.ts
@@ -286,6 +286,7 @@ export async function finalizeBugReportUpload(input: {
         debugger: createEmptyDebuggerPersistence(),
         id: existingReport.id,
         shareUrl: `/s/${existingReport.id}`,
+        submissionStatus: existingReport.submissionStatus,
         warnings: [],
       }
     }

--- a/packages/bug-reports/src/lib/upload-session.ts
+++ b/packages/bug-reports/src/lib/upload-session.ts
@@ -6,6 +6,7 @@ import {
 import {
   BUG_REPORT_DEBUGGER_INGESTION_STATUS_OPTIONS,
   BUG_REPORT_SUBMISSION_STATUS_OPTIONS,
+  type BugReportSubmissionStatus,
 } from "@crikket/shared/constants/bug-report"
 import {
   PRIORITY_OPTIONS,
@@ -249,6 +250,7 @@ export async function finalizeBugReportUpload(input: {
   debugger: PersistBugReportDebuggerDataResult
   id: string
   shareUrl: string
+  submissionStatus: BugReportSubmissionStatus
   warnings: string[]
 }> {
   const uploadSession = await db.query.bugReportUploadSession.findFirst({
@@ -390,15 +392,12 @@ export async function finalizeBugReportUpload(input: {
     })
     .where(eq(bugReport.id, uploadSession.id))
 
-  if (submissionStatus !== BUG_REPORT_SUBMISSION_STATUS_OPTIONS.ready) {
-    throw new ORPCError("INTERNAL_SERVER_ERROR", {
-      message: "Failed to process debugger data for this report.",
-    })
-  }
-
+  // Debugger ingestion is optional; the report is already persisted, so surface
+  // the failed status instead of 500ing the whole submission.
   return {
     id: uploadSession.id,
     shareUrl: `/s/${uploadSession.id}`,
+    submissionStatus,
     warnings,
     debugger: debuggerPersistence,
   }


### PR DESCRIPTION
Fixes #79.

Two related fixes for self-hosting on S3 backends that honor `Content-Encoding: gzip` (Garage, MinIO):

**1. Double decompression.** The debugger payload is uploaded with `Content-Encoding: gzip`, then read back and `gunzipSync`'d. Backends that honor the header transparently decompress on read, so `gunzipSync` receives plain JSON and throws `incorrect header check` (`Z_DATA_ERROR`). Fixed by gating decompression on the actual gzip magic bytes (`1f 8b`) instead of the recorded encoding — works whether or not the backend decompresses.

**2. Optional payload shouldn't 500 the report.** `finalizeBugReportUpload` threw `INTERNAL_SERVER_ERROR` when debugger ingestion failed, even though the report and screenshot were already persisted (the log labels it `[Non-fatal]`). Now it returns the `submissionStatus` instead, so a successful capture isn't discarded; the status is surfaced to the embed client.

Verified the stored object is valid gzip (`1f8b` magic, decompresses fine) — the corruption only happened on the read path via transparent decompression.

Changeset included.