### PR TITLE
fix(storage): verify object existence with a ranged GET so finalize survives proxy HEAD→GET rewrites

### DIFF
--- a/.changeset/storage-exists-ranged-get.md
+++ b/.changeset/storage-exists-ranged-get.md
@@ -1,0 +1,9 @@
+---
+"@crikket/bug-reports": patch
+---
+
+Fix bug report finalize failing with `403 SignatureDoesNotMatch` behind a CDN/proxy.
+
+The object existence check used at finalize signed a `HeadObject` request, but some CDNs/proxies (e.g. Cloudflare on a first-touch cache MISS) rewrite the first `HEAD` for a URL into a `GET`. That changes the SigV4 canonical request, so the object store rejects it with `403 SignatureDoesNotMatch` even though the object exists — and the check swallowed the error as "missing", surfacing to users as "Capture upload has not completed yet." for every report.
+
+The check now issues a single-byte ranged `GET` (signed as the method that is actually sent, so it survives the rewrite), treats a `416` as a present zero-byte object, and re-throws non-404 storage errors instead of masking a real failure as a missing object.

--- a/packages/bug-reports/src/lib/storage.ts
+++ b/packages/bug-reports/src/lib/storage.ts
@@ -1,7 +1,6 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
-  HeadObjectCommand,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3"
@@ -148,16 +147,39 @@ export function createS3StorageProvider(
       }
     },
     async exists(filename: string): Promise<boolean> {
+      // A signed HeadObject cannot be used here: some proxies (e.g. Cloudflare
+      // on a first-touch cache MISS) rewrite the first HEAD for a URL into a
+      // GET, which changes the SigV4 canonical request and makes the object's
+      // own storage reject it with 403 SignatureDoesNotMatch even though it
+      // exists. A single-byte ranged GET is signed as the method that is
+      // actually sent, so it survives the rewrite.
       try {
-        await client.send(
-          new HeadObjectCommand({
+        const response = await client.send(
+          new GetObjectCommand({
             Bucket: options.bucket,
             Key: filename,
+            Range: "bytes=0-0",
           })
         )
+        await drainStorageBody(response.Body)
         return true
-      } catch {
-        return false
+      } catch (error) {
+        if (isStorageNotFoundError(error)) {
+          return false
+        }
+
+        // A zero-byte object exists but cannot satisfy a byte range.
+        if (isRangeNotSatisfiableError(error)) {
+          return true
+        }
+
+        // Anything else (403, 5xx, DNS, timeout) is not "upload incomplete" —
+        // surface it instead of masking a real failure as a missing object.
+        const message =
+          error instanceof Error ? error.message : "Unknown storage error"
+        throw new Error(
+          `Failed to verify object ${filename} in cloud storage (bucket: ${options.bucket}, endpoint: ${options.endpoint ?? "aws-default"}): ${message}`
+        )
       }
     },
     async read(filename: string): Promise<Buffer> {
@@ -480,6 +502,85 @@ async function normalizeUploadBody(data: Blob | Buffer): Promise<Buffer> {
 
   const arrayBuffer = await data.arrayBuffer()
   return Buffer.from(arrayBuffer)
+}
+
+function getErrorHttpStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined
+  }
+
+  const metadata = (error as { $metadata?: { httpStatusCode?: number } })
+    .$metadata
+  if (metadata && typeof metadata.httpStatusCode === "number") {
+    return metadata.httpStatusCode
+  }
+
+  return undefined
+}
+
+function getErrorName(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined
+  }
+
+  const name = (error as { name?: unknown }).name
+  return typeof name === "string" ? name : undefined
+}
+
+export function isStorageNotFoundError(error: unknown): boolean {
+  if (getErrorHttpStatus(error) === 404) {
+    return true
+  }
+
+  const name = getErrorName(error)
+  return name === "NoSuchKey" || name === "NotFound"
+}
+
+export function isRangeNotSatisfiableError(error: unknown): boolean {
+  if (getErrorHttpStatus(error) === 416) {
+    return true
+  }
+
+  const name = getErrorName(error)
+  return name === "InvalidRange" || name === "RequestedRangeNotSatisfiable"
+}
+
+async function drainStorageBody(body: unknown): Promise<void> {
+  if (!body) {
+    return
+  }
+
+  try {
+    if (
+      typeof body === "object" &&
+      "transformToByteArray" in body &&
+      typeof (body as { transformToByteArray?: unknown })
+        .transformToByteArray === "function"
+    ) {
+      await (
+        body as { transformToByteArray: () => Promise<Uint8Array> }
+      ).transformToByteArray()
+      return
+    }
+
+    if (body instanceof ReadableStream) {
+      const reader = body.getReader()
+      while (true) {
+        const { done } = await reader.read()
+        if (done) {
+          break
+        }
+      }
+    }
+  } catch (error) {
+    // Draining the probe body is best-effort socket cleanup; a drain failure
+    // does not change whether the object exists, so report it without masking
+    // the existence result.
+    reportNonFatalError(
+      "Failed to drain storage existence-probe response body",
+      error
+    )
+  }
 }
 
 async function readBodyToBuffer(body: unknown): Promise<Buffer> {

--- a/packages/bug-reports/test/storage-exists.test.ts
+++ b/packages/bug-reports/test/storage-exists.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test"
+
+// Regression coverage for the object existence check used at finalize, which
+// previously swallowed *every* error and reported the object as
+// missing ("Capture upload has not completed yet."), which hid a real
+// 403 SignatureDoesNotMatch. These helpers now drive the decision: only a
+// genuine "not found" is false, a zero-byte object is present, and anything
+// else must surface.
+
+const envState = {
+  DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/crikket",
+  BETTER_AUTH_SECRET: "0123456789abcdef0123456789abcdef",
+  BETTER_AUTH_URL: "http://localhost:3000",
+  STORAGE_BUCKET: "bug-report-bucket",
+  STORAGE_REGION: "auto",
+  STORAGE_ENDPOINT: "https://example-account.r2.cloudflarestorage.com",
+  STORAGE_ADDRESSING_STYLE: undefined,
+  STORAGE_ACCESS_KEY_ID: "access",
+  STORAGE_SECRET_ACCESS_KEY: "secret",
+  STORAGE_PUBLIC_URL: undefined,
+}
+
+mock.module("@crikket/env/server", () => ({ env: envState }))
+mock.module("@crikket/db", () => ({
+  db: {
+    query: {
+      bugReportArtifactCleanup: {
+        findMany: async () => [],
+        findFirst: async () => null,
+      },
+    },
+    delete: () => ({ where: async () => undefined }),
+    insert: () => ({
+      values: () => ({ onConflictDoUpdate: async () => undefined }),
+    }),
+  },
+}))
+mock.module("@crikket/shared/lib/errors", () => ({
+  reportNonFatalError: () => undefined,
+}))
+
+let isStorageNotFoundError: typeof import("../src/lib/storage").isStorageNotFoundError
+let isRangeNotSatisfiableError: typeof import("../src/lib/storage").isRangeNotSatisfiableError
+
+beforeAll(async () => {
+  ;({ isStorageNotFoundError, isRangeNotSatisfiableError } = await import(
+    "../src/lib/storage"
+  ))
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+describe("isStorageNotFoundError", () => {
+  it("recognises a 404 status", () => {
+    expect(isStorageNotFoundError({ $metadata: { httpStatusCode: 404 } })).toBe(
+      true
+    )
+  })
+
+  it("recognises NoSuchKey / NotFound by name", () => {
+    expect(isStorageNotFoundError({ name: "NoSuchKey" })).toBe(true)
+    expect(isStorageNotFoundError({ name: "NotFound" })).toBe(true)
+  })
+
+  it("does NOT treat a 403 SignatureDoesNotMatch as missing", () => {
+    expect(
+      isStorageNotFoundError({
+        name: "SignatureDoesNotMatch",
+        $metadata: { httpStatusCode: 403 },
+      })
+    ).toBe(false)
+  })
+
+  it("does NOT treat a 500 as missing", () => {
+    expect(isStorageNotFoundError({ $metadata: { httpStatusCode: 500 } })).toBe(
+      false
+    )
+  })
+})
+
+describe("isRangeNotSatisfiableError", () => {
+  it("recognises a 416 status (zero-byte object)", () => {
+    expect(
+      isRangeNotSatisfiableError({ $metadata: { httpStatusCode: 416 } })
+    ).toBe(true)
+  })
+
+  it("recognises InvalidRange by name", () => {
+    expect(isRangeNotSatisfiableError({ name: "InvalidRange" })).toBe(true)
+  })
+
+  it("does NOT match a 403", () => {
+    expect(
+      isRangeNotSatisfiableError({ $metadata: { httpStatusCode: 403 } })
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #88

### Problem

Behind a CDN/proxy that rewrites a first-touch `HEAD` into a `GET` (e.g. Cloudflare on a cache MISS), the presigned `HeadObjectCommand` used by `exists()` at finalize is rejected with `403 SignatureDoesNotMatch` — the request is signed for `HEAD` but arrives at the origin as `GET`, so the SigV4 canonical request no longer matches. The `catch {}` then swallowed the `403` as "object missing", so finalize reported *"Capture upload has not completed yet."* for every bug report.

### Fix

`packages/bug-reports/src/lib/storage.ts`:

- Replace the presigned `HeadObjectCommand` with a single-byte ranged `GetObjectCommand` (`Range: bytes=0-0`). Because it is signed as the method that is actually sent, it survives the `HEAD → GET` rewrite. The tiny response body is drained for socket cleanup.
- Treat `416 RequestedRangeNotSatisfiable` / `InvalidRange` as a present (zero-byte) object.
- Only a genuine `404` / `NoSuchKey` / `NotFound` is reported as missing; any other error (403, 5xx, DNS, timeout) is re-thrown with context instead of being masked as a missing object.

### Tests

Adds `packages/bug-reports/test/storage-exists.test.ts` covering the not-found, zero-byte (416), and must-surface (403/500) classifications.

```
cd packages/bug-reports && bun test test
# 31 pass, 0 fail
bun run check-types   # clean
bunx ultracite check  # clean
```

`HeadObjectCommand` is no longer imported, so the change is otherwise behavior-preserving for direct-to-origin storage.
