### PR TITLE
fix(capture): rate limit the capture API by default without external Redis

### DIFF
--- a/.changeset/capture-default-rate-limit.md
+++ b/.changeset/capture-default-rate-limit.md
@@ -1,0 +1,9 @@
+---
+"server": patch
+---
+
+Rate limit the capture API by default, even when Upstash Redis is not configured.
+
+Previously the capture rate limiter and submit-token replay protection only engaged when `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` were set — so a self-hosted single instance ran the public capture endpoints with rate limiting entirely off.
+
+The limiter and single-use nonce store now fall back to an in-process fixed-window implementation when no external Redis is configured, so a single instance is protected out of the box. Upstash remains the backend when configured, sharing limits and replay protection across horizontally scaled instances.

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -11,8 +11,12 @@ CORS_ORIGINS=http://localhost:3001
 ALLOWED_SIGNUP_DOMAINS=*
 
 # ==========================================
-# RATE LIMITING (Upstash Redis)
+# RATE LIMITING (Upstash Redis) - Optional
 # ==========================================
+# The capture API is always rate limited. Leave these unset to use the
+# built-in in-process limiter (correct for a single instance). Set both to
+# use Upstash Redis so limits and token replay protection are shared across
+# multiple instances.
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
@@ -86,8 +90,8 @@ STORAGE_PUBLIC_URL=
 # CAPTURE SECURITY (Turnstile & submit tokens) - Optional
 # ==========================================
 # Enables signed capture submit tokens when set.
-# Upstash Redis is optional; when configured it enables rate limiting
-# and one-time submit token replay protection.
+# Rate limiting is always on (see RATE LIMITING above); Upstash only makes it
+# distributed across instances.
 # Turnstile is optional and only enforced when both keys are set.
 CAPTURE_SUBMIT_TOKEN_SECRET=
 TURNSTILE_SITE_KEY=

--- a/apps/server/src/capture/in-memory-rate-limit.ts
+++ b/apps/server/src/capture/in-memory-rate-limit.ts
@@ -1,0 +1,100 @@
+// In-memory fixed-window rate limiting and single-use nonce tracking for the
+// capture API. This is the default backend when no external Redis (Upstash) is
+// configured, so a self-hosted single-instance server is rate limited out of
+// the box rather than running with protection entirely off. A horizontally
+// scaled deployment should set UPSTASH_REDIS_REST_* to share state across
+// instances.
+
+export interface FixedWindowRateLimitResult {
+  limit: number
+  remaining: number
+  reset: number
+  success: boolean
+}
+
+export interface ScopedRateLimiter {
+  limit(key: string): Promise<FixedWindowRateLimitResult>
+}
+
+interface FixedWindowBucket {
+  count: number
+  resetAt: number
+}
+
+const MAX_TRACKED_KEYS = 50_000
+
+export class InMemoryFixedWindowRateLimiter implements ScopedRateLimiter {
+  private readonly buckets = new Map<string, FixedWindowBucket>()
+  private readonly maxRequests: number
+  private readonly windowMs: number
+
+  constructor(input: { limit: number; windowSeconds: number }) {
+    this.maxRequests = input.limit
+    this.windowMs = input.windowSeconds * 1000
+  }
+
+  limit(key: string): Promise<FixedWindowRateLimitResult> {
+    const now = Date.now()
+    let bucket = this.buckets.get(key)
+
+    if (!bucket || bucket.resetAt <= now) {
+      bucket = {
+        count: 0,
+        resetAt: now + this.windowMs,
+      }
+      this.buckets.set(key, bucket)
+    }
+
+    bucket.count += 1
+    this.pruneIfNeeded(now)
+
+    const success = bucket.count <= this.maxRequests
+    const remaining = Math.max(0, this.maxRequests - bucket.count)
+
+    return Promise.resolve({
+      limit: this.maxRequests,
+      remaining,
+      reset: bucket.resetAt,
+      success,
+    })
+  }
+
+  private pruneIfNeeded(now: number): void {
+    if (this.buckets.size <= MAX_TRACKED_KEYS) {
+      return
+    }
+
+    for (const [key, bucket] of this.buckets) {
+      if (bucket.resetAt <= now) {
+        this.buckets.delete(key)
+      }
+    }
+  }
+}
+
+export class InMemoryNonceStore {
+  private readonly nonces = new Map<string, number>()
+
+  // Reserves a nonce for the given TTL. Returns true when the nonce was newly
+  // reserved and false when it was already reserved (i.e. a replay).
+  reserve(key: string, ttlMs: number): boolean {
+    const now = Date.now()
+    this.pruneExpired(now)
+
+    const existingExpiry = this.nonces.get(key)
+    if (existingExpiry !== undefined && existingExpiry > now) {
+      return false
+    }
+
+    this.nonces.set(key, now + ttlMs)
+    return true
+  }
+
+  private pruneExpired(now: number): void {
+    for (const [key, expiresAt] of this.nonces) {
+      if (expiresAt <= now) {
+        this.nonces.delete(key)
+      }
+    }
+  }
+}

--- a/apps/server/src/capture/protection.ts
+++ b/apps/server/src/capture/protection.ts
@@ -1,7 +1,7 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto"
 import { env } from "@crikket/env/server"
 import { ORPCError } from "@orpc/server"
-import { getCaptureRedis } from "./security"
+import { reserveCaptureNonce } from "./security"
 
 const CAPTURE_SUBMIT_TOKEN_VERSION = 1
 const CAPTURE_SUBMIT_TOKEN_TTL_MS = 5 * 60 * 1000
@@ -398,19 +398,14 @@ async function consumeCaptureSubmitToken(input: {
   jti: string
   now: number
 }): Promise<void> {
-  const redis = getCaptureRedis()
-  if (!redis) {
-    return
-  }
-
   const ttlMs = Math.max(1, input.expiresAt - input.now)
   const replayKey = `${CAPTURE_SUBMIT_TOKEN_REPLAY_PREFIX}:${input.jti}`
-  const result = await redis.set(replayKey, "1", {
-    nx: true,
-    px: ttlMs,
+  const reserved = await reserveCaptureNonce({
+    key: replayKey,
+    ttlMs,
   })
 
-  if (result !== "OK") {
+  if (!reserved) {
     throw new ORPCError("UNAUTHORIZED", {
       data: {
         reasonCode: "replayed_submit_token",

--- a/apps/server/src/capture/security.ts
+++ b/apps/server/src/capture/security.ts
@@ -5,6 +5,11 @@ import { env } from "@crikket/env/server"
 import { ORPCError } from "@orpc/server"
 import { Ratelimit } from "@upstash/ratelimit"
 import { Redis } from "@upstash/redis"
+import {
+  InMemoryFixedWindowRateLimiter,
+  InMemoryNonceStore,
+  type ScopedRateLimiter,
+} from "./in-memory-rate-limit"
 
 const MAX_CAPTURE_REQUEST_BODY_BYTES = 110 * 1024 * 1024
 const MAX_CAPTURE_TOKEN_REQUEST_BODY_BYTES = 16 * 1024
@@ -55,9 +60,9 @@ type CaptureRateLimiters = {
 type CaptureRateLimitScope = keyof typeof CAPTURE_RATE_LIMIT_CONFIG
 
 type CaptureScopedRateLimiters = {
-  ip: Ratelimit
-  key: Ratelimit
-  origin: Ratelimit
+  ip: ScopedRateLimiter
+  key: ScopedRateLimiter
+  origin: ScopedRateLimiter
 }
 
 type RateLimitResult = {
@@ -69,6 +74,7 @@ type RateLimitResult = {
 
 let captureRateLimiters: CaptureRateLimiters | undefined
 let captureRedisClient: Redis | undefined
+let captureNonceStore: InMemoryNonceStore | undefined
 let lastRateLimitErrorLoggedAt = 0
 
 function getRateLimitWindow(windowSeconds: number): `${number} s` {
@@ -79,15 +85,16 @@ export function hasCaptureRedisConfig(): boolean {
   return Boolean(env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN)
 }
 
-function getCaptureRateLimiters(): CaptureRateLimiters | null {
-  const redis = getCaptureRedis()
-  if (!redis) {
-    return null
-  }
-
+// Rate limiting is always on. When Redis (Upstash) is configured the limiters
+// are distributed and shared across instances; otherwise they fall back to an
+// in-process fixed-window limiter so a self-hosted single instance is still
+// protected.
+function getCaptureRateLimiters(): CaptureRateLimiters {
   if (captureRateLimiters) {
     return captureRateLimiters
   }
+
+  const redis = getCaptureRedis()
 
   captureRateLimiters = {
     submit: createScopedCaptureRateLimiters({
@@ -104,29 +111,77 @@ function getCaptureRateLimiters(): CaptureRateLimiters | null {
 }
 
 function createScopedCaptureRateLimiters(input: {
-  redis: Redis
+  redis: Redis | null
   scope: CaptureRateLimitScope
 }): CaptureScopedRateLimiters {
   const config = CAPTURE_RATE_LIMIT_CONFIG[input.scope]
+  const redis = input.redis
+
+  if (!redis) {
+    return {
+      ip: new InMemoryFixedWindowRateLimiter({
+        limit: config.ipMax,
+        windowSeconds: config.windowSeconds,
+      }),
+      key: new InMemoryFixedWindowRateLimiter({
+        limit: config.keyMax,
+        windowSeconds: config.windowSeconds,
+      }),
+      origin: new InMemoryFixedWindowRateLimiter({
+        limit: config.originMax,
+        windowSeconds: config.windowSeconds,
+      }),
+    }
+  }
+
   const window = getRateLimitWindow(config.windowSeconds)
 
   return {
     ip: new Ratelimit({
-      redis: input.redis,
+      redis,
       limiter: Ratelimit.fixedWindow(config.ipMax, window),
       prefix: `${config.prefix}:ip`,
     }),
     key: new Ratelimit({
-      redis: input.redis,
+      redis,
       limiter: Ratelimit.fixedWindow(config.keyMax, window),
       prefix: `${config.prefix}:key`,
     }),
     origin: new Ratelimit({
-      redis: input.redis,
+      redis,
       limiter: Ratelimit.fixedWindow(config.originMax, window),
       prefix: `${config.prefix}:origin`,
     }),
   }
+}
+
+function getCaptureNonceStore(): InMemoryNonceStore {
+  if (!captureNonceStore) {
+    captureNonceStore = new InMemoryNonceStore()
+  }
+
+  return captureNonceStore
+}
+
+// Reserves a single-use nonce (for submit/finalize token replay protection).
+// Returns true when newly reserved, false on replay. Uses Redis when
+// configured, otherwise an in-process store so replay protection also works on
+// a single self-hosted instance.
+export async function reserveCaptureNonce(input: {
+  key: string
+  ttlMs: number
+}): Promise<boolean> {
+  const redis = getCaptureRedis()
+  if (redis) {
+    const result = await redis.set(input.key, "1", {
+      nx: true,
+      px: input.ttlMs,
+    })
+
+    return result === "OK"
+  }
+
+  return getCaptureNonceStore().reserve(input.key, input.ttlMs)
 }
 
 export function getCaptureRedis(): Redis | null {
@@ -274,7 +329,7 @@ function logRateLimitError(error: unknown): void {
 }
 
 async function limitWithFailOpen(
-  limiter: Ratelimit,
+  limiter: ScopedRateLimiter,
   key: string
 ): Promise<RateLimitResult | null> {
   try {
@@ -396,13 +451,6 @@ async function evaluateCaptureRateLimit(input: {
   }
 
   const limiters = getCaptureRateLimiters()
-  if (!limiters) {
-    return {
-      allowed: true,
-      headers: {},
-    }
-  }
-
   const scopedLimiters = limiters[input.scope]
   const config = CAPTURE_RATE_LIMIT_CONFIG[input.scope]
   const results: RateLimitResult[] = []

--- a/apps/server/test/in-memory-rate-limit.test.ts
+++ b/apps/server/test/in-memory-rate-limit.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  type FixedWindowRateLimitResult,
+  InMemoryFixedWindowRateLimiter,
+  InMemoryNonceStore,
+} from "../src/capture/in-memory-rate-limit"
+
+// Coverage for the default (no-Redis) capture protection backend.
+
+describe("InMemoryFixedWindowRateLimiter", () => {
+  it("allows requests up to the limit and blocks beyond it", async () => {
+    const limiter = new InMemoryFixedWindowRateLimiter({
+      limit: 3,
+      windowSeconds: 60,
+    })
+
+    const results: FixedWindowRateLimitResult[] = []
+    for (let index = 0; index < 4; index += 1) {
+      results.push(await limiter.limit("client-a"))
+    }
+
+    expect(results.map((result) => result.success)).toEqual([
+      true,
+      true,
+      true,
+      false,
+    ])
+    expect(results[0]?.remaining).toBe(2)
+    expect(results[3]?.remaining).toBe(0)
+    expect(results[3]?.limit).toBe(3)
+  })
+
+  it("tracks separate keys independently", async () => {
+    const limiter = new InMemoryFixedWindowRateLimiter({
+      limit: 1,
+      windowSeconds: 60,
+    })
+
+    expect((await limiter.limit("a")).success).toBe(true)
+    expect((await limiter.limit("a")).success).toBe(false)
+    expect((await limiter.limit("b")).success).toBe(true)
+  })
+
+  it("resets after the window elapses", async () => {
+    const limiter = new InMemoryFixedWindowRateLimiter({
+      limit: 1,
+      windowSeconds: 0.05,
+    })
+
+    expect((await limiter.limit("a")).success).toBe(true)
+    expect((await limiter.limit("a")).success).toBe(false)
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    expect((await limiter.limit("a")).success).toBe(true)
+  })
+})
+
+describe("InMemoryNonceStore", () => {
+  it("reserves a nonce once and rejects replays", () => {
+    const store = new InMemoryNonceStore()
+
+    expect(store.reserve("jti-1", 60_000)).toBe(true)
+    expect(store.reserve("jti-1", 60_000)).toBe(false)
+    expect(store.reserve("jti-2", 60_000)).toBe(true)
+  })
+
+  it("allows re-reservation after the ttl expires", async () => {
+    const store = new InMemoryNonceStore()
+
+    expect(store.reserve("jti-1", 40)).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 70))
+    expect(store.reserve("jti-1", 40)).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #90

### Problem

The capture rate limiter and submit-token replay protection engage **only** when Upstash Redis is configured. `getCaptureRateLimiters()` returns `null` without Redis and `evaluateCaptureRateLimit()` short-circuits to `allowed: true`, so a self-hosted single instance runs the public capture endpoints with rate limiting off.

### Proposal

This PR is a **proposal** — happy to adjust the design (window strategy, default limits, memory bounds, or a different library) to your preference.

`apps/server/src/capture/`:

- Add `in-memory-rate-limit.ts`: an `InMemoryFixedWindowRateLimiter` (matching the existing Upstash `fixedWindow` semantics) and an `InMemoryNonceStore` (single-use nonce reservation with TTL), both with light pruning to bound memory.
- `security.ts`: `getCaptureRateLimiters()` always returns limiters. With Redis it builds the distributed Upstash limiters as before; without Redis it builds in-process limiters. A new `reserveCaptureNonce()` uses Redis when present, otherwise the in-process store.
- `protection.ts`: `consumeCaptureSubmitToken()` uses `reserveCaptureNonce()` so replay protection also works without Redis.
- `.env.example`: document that rate limiting is always on and Upstash only makes it distributed across instances.

Existing behavior is unchanged when Upstash is configured (distributed limits + replay protection shared across instances). No new dependencies.

### Tests

Adds `apps/server/test/in-memory-rate-limit.test.ts` (window enforcement, per-key isolation, window reset, nonce single-use + TTL expiry).

```
cd apps/server && bun test test
# 20 pass, 0 fail
bun run check-types   # clean
bunx ultracite check  # clean
```
