### PR TITLE
fix(sdk): capture network/console from page load, not just after the widget opens

### DIFF
--- a/.changeset/capture-eager-debugger.md
+++ b/.changeset/capture-eager-debugger.md
@@ -1,0 +1,9 @@
+---
+"@crikket-io/capture": minor
+---
+
+Capture network/console activity from page load, not just from when the widget is opened.
+
+The network/console recorder previously installed only when a capture was started (button press), so requests made before that were never recorded and most screenshot reports said "No network requests were captured." The recorder now installs at `init()` by default and buffers events, and the buffered collector is handed to the eager runtime so nothing is lost across the lazy→eager handoff. A screenshot then replays the full retained window instead of only the short post-install lookback.
+
+Opt out with `collectDebuggerEagerly: false` to restore installing the recorder on first capture.

--- a/sdks/capture/README.md
+++ b/sdks/capture/README.md
@@ -80,6 +80,9 @@ Available options:
 - `mountTarget`: custom element to mount into; defaults to `document.body`
 - `submitPath`: custom bug report base path; defaults to `/api/embed/bug-reports`
 - `zIndex`: custom widget stacking order
+- `collectDebuggerEagerly`: install the network/console recorder at `init()`
+  instead of on first capture, so requests made before the widget is opened are
+  included in reports. Defaults to `true`.
 
 `submitPath` is used as the base path for the capture control-plane flow. By
 default the SDK derives these routes from `/api/embed/bug-reports`:

--- a/sdks/capture/src/debugger/lazy-debugger-collector.ts
+++ b/sdks/capture/src/debugger/lazy-debugger-collector.ts
@@ -13,9 +13,17 @@ export class LazyDebuggerCollector {
   private collector: DebuggerCollectorInstance | null = null
   private collectorPromise: Promise<DebuggerCollectorInstance> | null = null
 
-  async startScreenshotSession(): Promise<void> {
+  // Installs the page runtime (fetch/XHR/console interceptors) without starting
+  // a capture session, so events are buffered before the first capture.
+  async warmUp(): Promise<void> {
+    await this.ensureCollector()
+  }
+
+  async startScreenshotSession(
+    lookbackMs = SCREENSHOT_LOOKBACK_MS
+  ): Promise<void> {
     const collector = await this.ensureCollector()
-    collector.startSession("screenshot", SCREENSHOT_LOOKBACK_MS)
+    collector.startSession("screenshot", lookbackMs)
   }
 
   async startRecordingSession(): Promise<void> {

--- a/sdks/capture/src/plugin.tsx
+++ b/sdks/capture/src/plugin.tsx
@@ -21,6 +21,7 @@ export function CapturePlugin(
     const lifecycleVersion = lifecycleVersionRef.current
     const controller = init({
       autoMount: props.autoMount,
+      collectDebuggerEagerly: props.collectDebuggerEagerly,
       host: props.host,
       key: normalizedKey,
       mountTarget: props.mountTarget,
@@ -40,6 +41,7 @@ export function CapturePlugin(
     }
   }, [
     props.autoMount,
+    props.collectDebuggerEagerly,
     props.host,
     props.mountTarget,
     props.publicKey,

--- a/sdks/capture/src/runtime/capture-runtime.ts
+++ b/sdks/capture/src/runtime/capture-runtime.ts
@@ -1,3 +1,4 @@
+import { MAX_RECENT_EVENT_AGE_MS, SCREENSHOT_LOOKBACK_MS } from "../constants"
 import { LazyDebuggerCollector } from "../debugger/lazy-debugger-collector"
 import {
   captureScreenshot,
@@ -27,10 +28,22 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
   private submitTransport: CaptureSubmitTransport | undefined
   private mountedTarget: HTMLElement | null = null
   private mountedUi: MountedCaptureUi | null = null
-  private readonly debuggerCollector = new LazyDebuggerCollector()
+  private readonly debuggerCollector: LazyDebuggerCollector
+  private readonly ownsDebuggerCollector: boolean
+  private collectDebuggerEagerly = true
   private activeRecording: RecordingController | null = null
   private currentMedia: CapturedMedia | null = null
   private currentReview: ReviewSnapshot | null = null
+
+  constructor(options?: { debuggerCollector?: LazyDebuggerCollector }) {
+    if (options?.debuggerCollector) {
+      this.debuggerCollector = options.debuggerCollector
+      this.ownsDebuggerCollector = false
+    } else {
+      this.debuggerCollector = new LazyDebuggerCollector()
+      this.ownsDebuggerCollector = true
+    }
+  }
 
   init(options: CaptureInitOptions): CaptureRuntimeController {
     const config: CaptureRuntimeConfig = {
@@ -42,6 +55,18 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
 
     this.runtimeConfig = config
     this.submitTransport = options.submitTransport
+    this.collectDebuggerEagerly = options.collectDebuggerEagerly ?? true
+
+    // Start buffering network/console before the first capture. When the
+    // collector is injected (by the lazy runtime) it has already been warmed.
+    if (this.collectDebuggerEagerly && this.ownsDebuggerCollector) {
+      this.debuggerCollector.warmUp().catch((error) => {
+        console.error(
+          "[crikket-capture] Failed to start debugger collector",
+          error
+        )
+      })
+    }
 
     if (options.autoMount ?? true) {
       this.mount(options.mountTarget)
@@ -101,7 +126,9 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
     this.setUiHidden(false)
     this.mountedUi?.unmount()
     this.mountedUi = null
-    this.debuggerCollector.dispose()
+    if (this.ownsDebuggerCollector) {
+      this.debuggerCollector.dispose()
+    }
     this.mountedTarget = null
   }
 
@@ -183,7 +210,9 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
   async takeScreenshot(): Promise<Blob | null> {
     this.getRuntimeConfig()
     this.ensureBrowserContext()
-    await this.debuggerCollector.startScreenshotSession()
+    await this.debuggerCollector.startScreenshotSession(
+      this.getScreenshotLookbackMs()
+    )
 
     let blob: Blob
     try {
@@ -320,6 +349,15 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
     }
 
     this.mountedUi?.store.setTitleIfEmpty(captureTitle)
+  }
+
+  // With eager collection the recent-event buffer has been filling since init,
+  // so replay the full retained window; otherwise fall back to the short
+  // post-install lookback.
+  private getScreenshotLookbackMs(): number {
+    return this.collectDebuggerEagerly
+      ? MAX_RECENT_EVENT_AGE_MS
+      : SCREENSHOT_LOOKBACK_MS
   }
 
   private getRuntimeConfig(): CaptureRuntimeConfig {

--- a/sdks/capture/src/runtime/lazy-capture-runtime.ts
+++ b/sdks/capture/src/runtime/lazy-capture-runtime.ts
@@ -1,3 +1,4 @@
+import { LazyDebuggerCollector } from "../debugger/lazy-debugger-collector"
 import type {
   CaptureInitOptions,
   CaptureRuntimeConfig,
@@ -25,6 +26,7 @@ export class LazyCaptureSdkRuntime implements CaptureRuntimeController {
   private mountedLauncher: MountedCaptureLauncher | null = null
   private eagerRuntime: CaptureSdkRuntime | null = null
   private eagerRuntimePromise: Promise<CaptureSdkRuntime> | null = null
+  private debuggerCollector: LazyDebuggerCollector | null = null
   private lifecycleVersion = 0
 
   init(options: CaptureInitOptions): CaptureRuntimeController {
@@ -44,6 +46,19 @@ export class LazyCaptureSdkRuntime implements CaptureRuntimeController {
       submitPath: runtimeConfig.submitPath,
       zIndex: runtimeConfig.zIndex,
       submitTransport: this.submitTransport,
+    }
+
+    // Start capturing network/console at init so requests made before the user
+    // opens the widget are recorded. The buffered collector is handed to the
+    // eager runtime so nothing is lost across the lazy->eager handoff.
+    if (options.collectDebuggerEagerly ?? true) {
+      this.debuggerCollector = new LazyDebuggerCollector()
+      this.debuggerCollector.warmUp().catch((error) => {
+        console.error(
+          "[crikket-capture] Failed to start debugger collector",
+          error
+        )
+      })
     }
 
     if (options.autoMount ?? true) {
@@ -111,6 +126,8 @@ export class LazyCaptureSdkRuntime implements CaptureRuntimeController {
     this.eagerRuntimePromise = null
     this.eagerRuntime?.destroy()
     this.eagerRuntime = null
+    this.debuggerCollector?.dispose()
+    this.debuggerCollector = null
     this.runtimeConfig = null
     this.initOptions = null
     this.submitTransport = undefined
@@ -178,7 +195,11 @@ export class LazyCaptureSdkRuntime implements CaptureRuntimeController {
           throw new Error("Capture SDK runtime load was cancelled.")
         }
 
-        const runtime = new CaptureSdkRuntime()
+        const runtime = new CaptureSdkRuntime(
+          this.debuggerCollector
+            ? { debuggerCollector: this.debuggerCollector }
+            : undefined
+        )
         runtime.init({
           ...initOptions,
           autoMount: true,

--- a/sdks/capture/src/types.ts
+++ b/sdks/capture/src/types.ts
@@ -83,6 +83,12 @@ export interface CaptureInitOptions {
   submitPath?: string
   zIndex?: number
   submitTransport?: CaptureSubmitTransport
+  /**
+   * Install the network/console debugger at init() instead of on first
+   * capture, so requests made before the user opens the widget are captured.
+   * Defaults to true.
+   */
+  collectDebuggerEagerly?: boolean
 }
 
 export interface CaptureRuntimeConfig {

--- a/sdks/capture/test/capture-failure.test.ts
+++ b/sdks/capture/test/capture-failure.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 
+import { MAX_RECENT_EVENT_AGE_MS } from "../src/constants"
 import {
   getCaptureSdk,
   sdkTestState,
@@ -28,7 +29,7 @@ describe("capture SDK capture failure regression", () => {
     expect(sdkTestState.startSessionCalls).toEqual([
       {
         captureType: "screenshot",
-        lookbackMs: 10_000,
+        lookbackMs: MAX_RECENT_EVENT_AGE_MS,
       },
     ])
     expect(sdkTestState.uiHidden).toEqual([true, false])

--- a/sdks/capture/test/eager-debugger.test.ts
+++ b/sdks/capture/test/eager-debugger.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  MAX_RECENT_EVENT_AGE_MS,
+  SCREENSHOT_LOOKBACK_MS,
+} from "../src/constants"
+import {
+  getCaptureSdk,
+  sdkTestState,
+  setupCaptureSdkTestHooks,
+  waitFor,
+} from "./lib/sdk-test-harness"
+
+setupCaptureSdkTestHooks()
+
+// Regression coverage: the network/console collector must be installed at
+// init() so requests made before the widget is opened are captured, not only
+// from the moment the capture button is pressed.
+
+describe("capture SDK eager debugger collection", () => {
+  it("installs the debugger collector at init by default, before any capture", async () => {
+    const capture = getCaptureSdk()
+
+    capture.init({
+      key: "crk_eager",
+      host: "https://api.crikket.io",
+    })
+
+    await waitFor(() => sdkTestState.installCalls === 1)
+
+    // Installed, but no capture session has started yet.
+    expect(sdkTestState.startSessionCalls).toEqual([])
+  })
+
+  it("replays the full retained buffer as the screenshot lookback when eager", async () => {
+    const capture = getCaptureSdk()
+
+    capture.init({ key: "crk_eager", host: "https://api.crikket.io" })
+    await waitFor(() => sdkTestState.installCalls === 1)
+
+    await capture.takeScreenshot()
+
+    expect(sdkTestState.startSessionCalls).toEqual([
+      { captureType: "screenshot", lookbackMs: MAX_RECENT_EVENT_AGE_MS },
+    ])
+    // Collector installed exactly once (warm-up reused by the capture session).
+    expect(sdkTestState.installCalls).toBe(1)
+  })
+
+  it("defers installation to first capture when collectDebuggerEagerly is false", async () => {
+    const capture = getCaptureSdk()
+
+    capture.init({
+      key: "crk_lazy",
+      host: "https://api.crikket.io",
+      collectDebuggerEagerly: false,
+    })
+
+    // Give any accidental warm-up a chance to run.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(sdkTestState.installCalls).toBe(0)
+
+    await capture.takeScreenshot()
+
+    expect(sdkTestState.installCalls).toBe(1)
+    expect(sdkTestState.startSessionCalls).toEqual([
+      { captureType: "screenshot", lookbackMs: SCREENSHOT_LOOKBACK_MS },
+    ])
+  })
+})

--- a/sdks/capture/test/lib/sdk-test-harness.ts
+++ b/sdks/capture/test/lib/sdk-test-harness.ts
@@ -65,6 +65,7 @@ export const sdkTestState = {
   uiShowSuccessUrls: [] as Array<string | undefined>,
   titlePrefills: [] as string[],
   uiUnmounts: 0,
+  installCalls: 0,
   startSessionCalls: [] as StartSessionCall[],
   markRecordingStartedCalls: [] as number[],
   finalizeSessionCalls: 0,
@@ -185,7 +186,7 @@ mock.module(CAPTURE_MEDIA_PATH, () => ({
 mock.module(DEBUGGER_COLLECTOR_PATH, () => ({
   DebuggerCollector: class DebuggerCollector {
     install(): void {
-      // Install work is irrelevant in the flow regression tests.
+      sdkTestState.installCalls += 1
     }
 
     startSession(
@@ -267,6 +268,7 @@ export function resetSdkTestState(): void {
   sdkTestState.uiShowSuccessUrls = []
   sdkTestState.titlePrefills = []
   sdkTestState.uiUnmounts = 0
+  sdkTestState.installCalls = 0
   sdkTestState.startSessionCalls = []
   sdkTestState.markRecordingStartedCalls = []
   sdkTestState.finalizeSessionCalls = 0

--- a/sdks/capture/test/screenshot-flow.test.ts
+++ b/sdks/capture/test/screenshot-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 
-import { SCREENSHOT_LOOKBACK_MS } from "../src/constants"
+import { MAX_RECENT_EVENT_AGE_MS } from "../src/constants"
 import {
   browserTarget,
   createSubmitTransport,
@@ -44,7 +44,7 @@ describe("capture SDK screenshot flow", () => {
     expect(sdkTestState.startSessionCalls).toEqual([
       {
         captureType: "screenshot",
-        lookbackMs: SCREENSHOT_LOOKBACK_MS,
+        lookbackMs: MAX_RECENT_EVENT_AGE_MS,
       },
     ])
     expect(sdkTestState.uiShowReviewInputs).toHaveLength(1)


### PR DESCRIPTION
Closes #94

### Problem

The network/console recorder installs only when a capture session starts (button press), so anything that happened before the user opened the widget is never intercepted — which is why most reports show "No network requests were captured."

### Fix

- Install the recorder at `init()` by default and buffer events (`LazyDebuggerCollector.warmUp()`), so requests made before the widget opens are recorded.
- The warmed collector is handed to the eager runtime across the lazy→eager handoff (injected via the `CaptureSdkRuntime` constructor) so nothing is lost, and only the runtime that owns the collector disposes it.
- A screenshot replays the full retained window (`MAX_RECENT_EVENT_AGE_MS`) instead of the short post-install lookback when eager collection is on.
- New `collectDebuggerEagerly` init option (default `true`) to opt out and restore installing on first capture.

### Tests

- Adds `test/eager-debugger.test.ts`: recorder installed once at init before any capture; full-buffer lookback replayed on screenshot; deferred install when `collectDebuggerEagerly: false`.
- Updates `test/screenshot-flow.test.ts` and `test/capture-failure.test.ts` for the eager lookback, and the harness to count `install()` calls.

```
cd sdks/capture && bun test test   # 13 pass, 0 fail
bun run check-types                 # clean
bunx ultracite check               # clean
```

> Note: part of a small set of related capture-SDK PRs that also touch the runtime/types; independent but may need a trivial rebase depending on merge order.
