### PR TITLE
feat(sdk): mobile capture via Upload Screenshot when getDisplayMedia is unavailable

### DIFF
--- a/.changeset/capture-mobile-upload.md
+++ b/.changeset/capture-mobile-upload.md
@@ -1,0 +1,7 @@
+---
+"@crikket-io/capture": minor
+---
+
+Support capturing bug reports on mobile browsers.
+
+Screen capture (`getDisplayMedia`) is a desktop-only web feature — iOS Safari does not define it and Android browsers define it but always reject it — so on mobile the launcher previously offered controls that threw at the moment of use. The widget now detects when display capture is not usable (an API check combined with a coarse mobile check that treats Android's defines-but-rejects behavior as unsupported) and offers an **Upload Screenshot** path instead, attaching an OS screenshot through the same review + submit pipeline. Console/network/URL/device context is still collected. Adds `attachScreenshotFile(file)` to drive this programmatically.

--- a/sdks/capture/README.md
+++ b/sdks/capture/README.md
@@ -81,6 +81,15 @@ Available options:
 - `submitPath`: custom bug report base path; defaults to `/api/embed/bug-reports`
 - `zIndex`: custom widget stacking order
 
+### Mobile browsers
+
+Screen capture (`getDisplayMedia`) is a desktop-only web feature — no mobile
+browser implements it. On mobile the widget automatically offers an **Upload
+Screenshot** path instead of Record/Screenshot, so a user can attach an
+OS screenshot; console, network, URL and device context are still collected.
+You can also drive this programmatically with
+`attachScreenshotFile(file: Blob)`.
+
 `submitPath` is used as the base path for the capture control-plane flow. By
 default the SDK derives these routes from `/api/embed/bug-reports`:
 

--- a/sdks/capture/src/browser.ts
+++ b/sdks/capture/src/browser.ts
@@ -1,4 +1,5 @@
 import {
+  attachScreenshotFile,
   close,
   defaultSubmitTransport,
   destroy,
@@ -17,6 +18,7 @@ import {
 import type { CaptureGlobalApi } from "./types"
 
 const capture = {
+  attachScreenshotFile,
   close,
   defaultSubmitTransport,
   destroy,

--- a/sdks/capture/src/eager.ts
+++ b/sdks/capture/src/eager.ts
@@ -59,6 +59,10 @@ export function takeScreenshot(): Promise<Blob | null> {
   return runtime.takeScreenshot()
 }
 
+export function attachScreenshotFile(file: Blob): Promise<Blob | null> {
+  return runtime.attachScreenshotFile(file)
+}
+
 export function submit(
   draft: CaptureSubmissionDraft
 ): Promise<CaptureSubmitResult> {

--- a/sdks/capture/src/index.ts
+++ b/sdks/capture/src/index.ts
@@ -59,6 +59,10 @@ export function takeScreenshot(): Promise<Blob | null> {
   return runtime.takeScreenshot()
 }
 
+export function attachScreenshotFile(file: Blob): Promise<Blob | null> {
+  return runtime.attachScreenshotFile(file)
+}
+
 export function submit(
   draft: CaptureSubmissionDraft
 ): Promise<CaptureSubmitResult> {

--- a/sdks/capture/src/media/capabilities.ts
+++ b/sdks/capture/src/media/capabilities.ts
@@ -1,0 +1,48 @@
+// Screen capture (getDisplayMedia) is a desktop-only web feature. iOS Safari
+// does not define it at all, and Chrome/Firefox for Android define the API but
+// always reject it — so feature detection alone ("getDisplayMedia" in
+// mediaDevices) is not enough and would present a launcher that fails only at
+// the moment of use. We therefore combine an API check with a coarse mobile
+// check, and offer a file-upload capture path where display capture is not
+// usable.
+
+const MOBILE_UA_REGEX =
+  /android|iphone|ipad|ipod|iemobile|blackberry|opera mini|mobile/i
+const MACINTOSH_UA_REGEX = /Macintosh/
+
+interface NavigatorUAData {
+  mobile?: boolean
+}
+
+export function isLikelyMobileDevice(): boolean {
+  if (typeof navigator === "undefined") {
+    return false
+  }
+
+  const uaData = (navigator as Navigator & { userAgentData?: NavigatorUAData })
+    .userAgentData
+  if (uaData && typeof uaData.mobile === "boolean") {
+    return uaData.mobile
+  }
+
+  const userAgent = navigator.userAgent ?? ""
+  if (MOBILE_UA_REGEX.test(userAgent)) {
+    return true
+  }
+
+  // iPadOS Safari reports a desktop ("Macintosh") user agent but is touch-first
+  // and has no working getDisplayMedia.
+  const maxTouchPoints = navigator.maxTouchPoints ?? 0
+  return MACINTOSH_UA_REGEX.test(userAgent) && maxTouchPoints > 1
+}
+
+export function supportsDisplayCapture(): boolean {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.mediaDevices?.getDisplayMedia
+  ) {
+    return false
+  }
+
+  return !isLikelyMobileDevice()
+}

--- a/sdks/capture/src/runtime/capture-runtime.ts
+++ b/sdks/capture/src/runtime/capture-runtime.ts
@@ -80,6 +80,12 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
           throw new Error("Screenshot capture failed.")
         }
       },
+      onUploadScreenshot: async (file) => {
+        const blob = await this.attachScreenshotFile(file)
+        if (!blob) {
+          throw new Error("Screenshot upload failed.")
+        }
+      },
       onStopRecording: async () => {
         const blob = await this.stopRecording()
         if (!blob) {
@@ -201,6 +207,35 @@ export class CaptureSdkRuntime implements CaptureRuntimeController {
     })
 
     return blob
+  }
+
+  // Attaches an image the user already has (e.g. an OS screenshot) as a
+  // screenshot capture. This is the capture path for mobile browsers, where
+  // getDisplayMedia is unavailable.
+  async attachScreenshotFile(file: Blob): Promise<Blob | null> {
+    this.getRuntimeConfig()
+    this.ensureBrowserContext()
+
+    if (!(file instanceof Blob) || file.size === 0) {
+      throw new Error("Please choose an image file to attach.")
+    }
+
+    if (file.type && !file.type.startsWith("image/")) {
+      throw new Error("Only image files can be attached as a screenshot.")
+    }
+
+    // No display capture and nothing is being screen-grabbed, so the widget UI
+    // does not need to be hidden. Still open a debugger session so the report
+    // carries the console/network context collected on this page.
+    await this.debuggerCollector.startScreenshotSession()
+
+    await this.finalizeCapturedMedia({
+      blob: file,
+      captureType: "screenshot",
+      durationMs: null,
+    })
+
+    return file
   }
 
   async submit(

--- a/sdks/capture/src/runtime/lazy-capture-runtime.ts
+++ b/sdks/capture/src/runtime/lazy-capture-runtime.ts
@@ -135,6 +135,11 @@ export class LazyCaptureSdkRuntime implements CaptureRuntimeController {
     return runtime.takeScreenshot()
   }
 
+  async attachScreenshotFile(file: Blob): Promise<Blob | null> {
+    const runtime = await this.loadEagerRuntime(false)
+    return runtime.attachScreenshotFile(file)
+  }
+
   async submit(draft: CaptureSubmissionDraft): Promise<CaptureSubmitResult> {
     const runtime = await this.loadEagerRuntime(false)
     return runtime.submit(draft)

--- a/sdks/capture/src/types.ts
+++ b/sdks/capture/src/types.ts
@@ -186,6 +186,7 @@ export interface CaptureRuntimeController {
   startRecording: () => Promise<{ startedAt: number }>
   stopRecording: () => Promise<Blob | null>
   takeScreenshot: () => Promise<Blob | null>
+  attachScreenshotFile: (file: Blob) => Promise<Blob | null>
   submit: (draft: CaptureSubmissionDraft) => Promise<CaptureSubmitResult>
   reset: () => void
   isInitialized: () => boolean

--- a/sdks/capture/src/ui/capture-widget/capture-widget-view.tsx
+++ b/sdks/capture/src/ui/capture-widget/capture-widget-view.tsx
@@ -23,6 +23,7 @@ export function CaptureWidgetView(props: {
         busy={props.isBusy}
         onStartVideo={props.handlers.onStartVideo}
         onTakeScreenshot={props.handlers.onTakeScreenshot}
+        onUploadScreenshot={props.handlers.onUploadScreenshot}
       />
     )
   }

--- a/sdks/capture/src/ui/capture-widget/hooks/use-capture-ui-handlers.ts
+++ b/sdks/capture/src/ui/capture-widget/hooks/use-capture-ui-handlers.ts
@@ -87,6 +87,15 @@ export function useCaptureUiHandlers(
           }
         })
       },
+      onUploadScreenshot: (file: File) => {
+        startBusyTask(async () => {
+          try {
+            await input.callbacks.onUploadScreenshot(file)
+          } catch (error) {
+            showCaptureError(error)
+          }
+        })
+      },
       onStopRecording: () => {
         startBusyTask(async () => {
           try {

--- a/sdks/capture/src/ui/capture-widget/sections/chooser-section.tsx
+++ b/sdks/capture/src/ui/capture-widget/sections/chooser-section.tsx
@@ -1,34 +1,73 @@
+import { useMemo, useRef } from "react"
+import { supportsDisplayCapture } from "../../../media/capabilities"
 import { Button } from "../components/primitives/button"
 
 export function ChooserSection(props: {
   busy: boolean
   onStartVideo: () => void
   onTakeScreenshot: () => void
+  onUploadScreenshot: (file: File) => void
 }): React.JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const canDisplayCapture = useMemo(() => supportsDisplayCapture(), [])
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    // Reset so choosing the same file again re-triggers change.
+    event.target.value = ""
+    if (file) {
+      props.onUploadScreenshot(file)
+    }
+  }
+
   return (
     <section className="grid gap-4 p-5">
       <p className="m-0 text-muted-foreground text-sm">
-        Choose how to capture the issue.
+        {canDisplayCapture
+          ? "Choose how to capture the issue."
+          : "Screen capture isn't available on this browser. Attach a screenshot to file a report."}
       </p>
-      <div className="grid grid-cols-2 gap-2">
-        <Button
-          className="w-full"
-          disabled={props.busy}
-          onClick={props.onStartVideo}
-          type="button"
-        >
-          Record Video
-        </Button>
-        <Button
-          className="w-full"
-          disabled={props.busy}
-          onClick={props.onTakeScreenshot}
-          type="button"
-          variant="outline"
-        >
-          Take Screenshot
-        </Button>
-      </div>
+
+      {canDisplayCapture ? (
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            className="w-full"
+            disabled={props.busy}
+            onClick={props.onStartVideo}
+            type="button"
+          >
+            Record Video
+          </Button>
+          <Button
+            className="w-full"
+            disabled={props.busy}
+            onClick={props.onTakeScreenshot}
+            type="button"
+            variant="outline"
+          >
+            Take Screenshot
+          </Button>
+        </div>
+      ) : null}
+
+      <Button
+        className="w-full"
+        disabled={props.busy}
+        onClick={() => fileInputRef.current?.click()}
+        type="button"
+        variant={canDisplayCapture ? "outline" : "primary"}
+      >
+        Upload Screenshot
+      </Button>
+
+      <input
+        accept="image/*"
+        className="sr-only"
+        onChange={handleFileChange}
+        ref={fileInputRef}
+        tabIndex={-1}
+        type="file"
+      />
     </section>
   )
 }

--- a/sdks/capture/src/ui/types.ts
+++ b/sdks/capture/src/ui/types.ts
@@ -29,6 +29,7 @@ export interface CaptureUiHandlers {
   onClose: () => void
   onStartVideo: () => void
   onTakeScreenshot: () => void
+  onUploadScreenshot: (file: File) => void
   onStopRecording: () => void
   onSubmit: (
     draft: CaptureSubmissionDraft,
@@ -44,6 +45,7 @@ export interface CaptureUiCallbacks {
   onClose: () => void
   onStartVideo: () => Promise<{ startedAt: number }>
   onTakeScreenshot: () => Promise<void>
+  onUploadScreenshot: (file: File) => Promise<void>
   onStopRecording: () => Promise<void>
   onSubmit: (
     draft: CaptureSubmissionDraft,

--- a/sdks/capture/test/capabilities.test.ts
+++ b/sdks/capture/test/capabilities.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "bun:test"
+
+import {
+  isLikelyMobileDevice,
+  supportsDisplayCapture,
+} from "../src/media/capabilities"
+
+// Regression coverage: display-capture support detection must not rely on
+// `"getDisplayMedia" in navigator.mediaDevices`, because Android browsers
+// define the API but always reject it.
+
+const originalNavigator = globalThis.navigator
+
+function setNavigator(value: Record<string, unknown>): void {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value,
+  })
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  })
+})
+
+describe("isLikelyMobileDevice", () => {
+  it("trusts userAgentData.mobile when present", () => {
+    setNavigator({ userAgentData: { mobile: true }, userAgent: "" })
+    expect(isLikelyMobileDevice()).toBe(true)
+
+    setNavigator({ userAgentData: { mobile: false }, userAgent: "" })
+    expect(isLikelyMobileDevice()).toBe(false)
+  })
+
+  it("detects Android and iPhone user agents", () => {
+    setNavigator({ userAgent: "Mozilla/5.0 (Linux; Android 14) Chrome/120" })
+    expect(isLikelyMobileDevice()).toBe(true)
+
+    setNavigator({ userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)" })
+    expect(isLikelyMobileDevice()).toBe(true)
+  })
+
+  it("treats a plain desktop Mac/Windows as not mobile", () => {
+    setNavigator({
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      maxTouchPoints: 0,
+    })
+    expect(isLikelyMobileDevice()).toBe(false)
+  })
+
+  it("detects touch-first iPadOS reporting a Macintosh UA", () => {
+    setNavigator({
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari",
+      maxTouchPoints: 5,
+    })
+    expect(isLikelyMobileDevice()).toBe(true)
+  })
+})
+
+describe("supportsDisplayCapture", () => {
+  it("is true on desktop when getDisplayMedia exists", () => {
+    setNavigator({
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      maxTouchPoints: 0,
+      mediaDevices: { getDisplayMedia: () => Promise.resolve({}) },
+    })
+    expect(supportsDisplayCapture()).toBe(true)
+  })
+
+  it("is false on Android even though getDisplayMedia is defined", () => {
+    setNavigator({
+      userAgent: "Mozilla/5.0 (Linux; Android 14) Chrome/120 Mobile",
+      mediaDevices: { getDisplayMedia: () => Promise.reject(new Error("no")) },
+    })
+    expect(supportsDisplayCapture()).toBe(false)
+  })
+
+  it("is false when getDisplayMedia is missing (iOS Safari)", () => {
+    setNavigator({
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)",
+      mediaDevices: {},
+    })
+    expect(supportsDisplayCapture()).toBe(false)
+  })
+})

--- a/sdks/capture/test/upload-flow.test.ts
+++ b/sdks/capture/test/upload-flow.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  createSubmitTransport,
+  getCaptureSdk,
+  sdkTestState,
+  setupCaptureSdkTestHooks,
+} from "./lib/sdk-test-harness"
+
+setupCaptureSdkTestHooks()
+
+const IMAGE_FILES_ERROR_REGEX = /image files/
+const CHOOSE_IMAGE_ERROR_REGEX = /choose an image/
+
+// Regression coverage: mobile browsers cannot use getDisplayMedia, so an
+// uploaded image must be a first-class screenshot capture path that flows
+// through the same review + submit pipeline without ever calling getDisplayMedia.
+
+describe("capture SDK upload screenshot flow", () => {
+  it("attaches an uploaded image as a screenshot and shows the review", async () => {
+    const capture = getCaptureSdk()
+
+    capture.init({
+      key: "crk_upload",
+      host: "https://api.crikket.io",
+      submitTransport: createSubmitTransport(),
+    })
+
+    const uploaded = new Blob(["uploaded-image"], { type: "image/png" })
+    const blob = await capture.attachScreenshotFile(uploaded)
+
+    expect(blob).toBe(uploaded)
+    // The uploaded blob, not a getDisplayMedia screenshot, is what gets reviewed.
+    expect(sdkTestState.uiShowReviewInputs).toHaveLength(1)
+    expect(sdkTestState.uiShowReviewInputs[0]).toMatchObject({
+      media: {
+        blob: uploaded,
+        captureType: "screenshot",
+        durationMs: null,
+      },
+    })
+    // No screen grab happened, so the widget UI is never hidden (only the
+    // ensure-visible call from finalize, never hidden(true)).
+    expect(sdkTestState.uiHidden).not.toContain(true)
+    expect(sdkTestState.startSessionCalls).toEqual([
+      { captureType: "screenshot", lookbackMs: expect.any(Number) },
+    ])
+
+    const result = await capture.submit({
+      title: "Mobile bug",
+      description: "From a phone",
+      priority: "medium",
+    })
+
+    expect(result).toEqual({
+      reportId: "br_123",
+      shareUrl: "https://app.crikket.io/s/br_123",
+    })
+    expect(sdkTestState.submitRequests[0]).toMatchObject({
+      report: { captureType: "screenshot", media: uploaded },
+    })
+  })
+
+  it("rejects a non-image upload", async () => {
+    const capture = getCaptureSdk()
+
+    capture.init({ key: "crk_upload", host: "https://api.crikket.io" })
+
+    const notImage = new Blob(["hello"], { type: "text/plain" })
+    await expect(capture.attachScreenshotFile(notImage)).rejects.toThrow(
+      IMAGE_FILES_ERROR_REGEX
+    )
+  })
+
+  it("rejects an empty upload", async () => {
+    const capture = getCaptureSdk()
+
+    capture.init({ key: "crk_upload", host: "https://api.crikket.io" })
+
+    const empty = new Blob([], { type: "image/png" })
+    await expect(capture.attachScreenshotFile(empty)).rejects.toThrow(
+      CHOOSE_IMAGE_ERROR_REGEX
+    )
+  })
+})


### PR DESCRIPTION
Closes #96

### Problem

The widget's only capture paths (Record Video / Take Screenshot) go through `getDisplayMedia`, which no mobile browser supports — iOS Safari doesn't define it and Android browsers define it but always reject it — so on mobile the controls throw at the moment of use.

### Fix

- `media/capabilities.ts`: `supportsDisplayCapture()` combines an API check with a coarse mobile check (`isLikelyMobileDevice()`), treating Android's defines-but-rejects behavior as unsupported and touch-first iPadOS (which reports a `Macintosh` UA) as mobile.
- When display capture isn't usable, the chooser hides Record/Screenshot and offers an **Upload Screenshot** path (an `<input type="file" accept="image/*">`) that attaches an OS screenshot through the existing review + submit pipeline. Console/network/URL/device context is still collected.
- Adds `attachScreenshotFile(file)` (exported and on the runtime controller) to drive the same path programmatically, with validation (must be a non-empty image blob).

### Scope note

This handles attaching an image, the natural mobile flow. A **pure text-only** report (no media) is intentionally out of scope: the submit/finalize pipeline currently expects a media object, so that would need a separate server-side change — I'd rather not half-ship it here. Happy to follow up if you'd like it.

### Tests

- `test/capabilities.test.ts`: mobile/desktop/iPadOS detection and `supportsDisplayCapture()` across iOS (no API), Android (defines-but-rejects), desktop.
- `test/upload-flow.test.ts`: an uploaded image flows through review + submit as a screenshot without ever calling `getDisplayMedia`, and non-image / empty uploads are rejected.

```
cd sdks/capture && bun test test   # 20 pass, 0 fail
bun run check-types                 # clean
bunx ultracite check               # clean
```

> Note: part of a small set of related capture-SDK PRs that also touch the runtime/types; independent but may need a trivial rebase depending on merge order.
